### PR TITLE
Several updates to popup and menus, and menu tests.

### DIFF
--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -25,6 +25,11 @@ export interface IMenuOptions extends IPopupOptions {
   isSubMenu?: boolean;
   selectOnOpen?: boolean;
   menuCssClass?: string;    // If provided, applies the css class to the menu container.
+
+  // If given, the menu will set the `weasel-popup-open` css class on the matching ancestor of the
+  // trigger element (in addition to setting it on the trigger element itself). Useful to keep an
+  // element highlighted while an associated menu is open.
+  parentSelectorToMark?: string;
 }
 
 export interface ISubMenuOptions {
@@ -102,6 +107,14 @@ export class Menu extends Disposable implements IPopupContent {
 
   constructor(private ctl: IOpenController, items: DomElementArg[], options: IMenuOptions = {}) {
     super();
+
+    // Set `weasel-popup-open` class on the ancestor of trigger that matches parentSelectorToMark.
+    if (options && options.parentSelectorToMark) {
+      const parent = ctl.getTriggerElem().closest(options.parentSelectorToMark);
+      if (parent) {
+        ctl.setOpenClass(parent);
+      }
+    }
 
     this.content = cssMenu({class: options.menuCssClass || ''},
       items,

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -78,6 +78,16 @@ export function menuItem(action: () => void, ...args: DomElementArg[]): Element 
   );
 }
 
+/**
+ * A version of menuItem that's an <a> link element.
+ */
+export function menuItemLink(...args: DomElementArg[]): Element {
+  return cssMenuItemLink({tabindex: '-1'}, cssMenuItem.cls(''), ...args,
+    // This prevents propagation, but NOT the default action, which is to open the link.
+    onKeyDown({Enter$: (ev) => ev.stopPropagation()})
+  );
+}
+
 export function onMenuItemSelected(yesNo: boolean, elem: Element) {
   if (yesNo) { (elem as HTMLElement).focus(); }
   elem.classList.toggle(cssMenuItem.className + '-sel', yesNo);
@@ -89,6 +99,12 @@ const defaultMenuOptions: IMenuOptions = {
   placement: 'bottom-start',
   showDelay: 0,
   trigger: ['click'],
+  modifiers: {
+    // gpuAcceleration (true by default) causes a tiny UI artifact: attempting to drag a link, at
+    // least in Firefox, causes it to be dragged from a different location on the screen where it
+    // actually is, which looks strange. Disabling has no noticeable downsides.
+    computeStyle: {gpuAcceleration: false}
+  },
 };
 
 /**
@@ -284,6 +300,24 @@ export const cssMenuItem = styled('li', `
     cursor: pointer;
     background-color: var(--weaseljs-selected-background-color, #5AC09C);
     color:            var(--weaseljs-selected-color, white);
+  }
+`);
+
+export const cssMenuItemLink = styled('a', `
+  display: flex;
+  justify-content: space-between;
+  outline: none;
+  padding: var(--weaseljs-menu-item-padding, 8px 24px);
+  user-select: none;
+  -moz-user-select: none;
+
+  &, &:hover, &:focus {
+    color: inherit;
+    text-decoration: none;
+    outline: none;
+  }
+  &.${cssMenuItem.className}-sel {
+    color: var(--weaseljs-selected-color, white);
   }
 `);
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/gristlabs/weasel.js#readme",
   "dependencies": {
-    "grainjs": "git+https://github.com/gristlabs/grainjs.git#44d563adbab3730bd116cbbff73ee9842b289a53",
+    "grainjs": "git+https://github.com/gristlabs/grainjs.git#3d884cd7e7c10cd1c5179a605035a59aa8eab0d0",
     "lodash": "^4.17.11",
     "popper.js": "1.14.6"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cache-loader": "^1.2.5",
     "fork-ts-checker-webpack-plugin": "^0.5.1",
     "mocha": "5.2.0",
-    "mocha-webdriver": "^0.1.6",
+    "mocha-webdriver": "^0.1.7",
     "ts-loader": "^5.3.0",
     "ts-node": "7.0.1",
     "tslint": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/gristlabs/weasel.js#readme",
   "dependencies": {
-    "grainjs": "git+https://github.com/gristlabs/grainjs.git#3d884cd7e7c10cd1c5179a605035a59aa8eab0d0",
+    "grainjs": "git+https://github.com/gristlabs/grainjs.git#975f9df3830d96800e10ce9d4a3dda5f053fe290",
     "lodash": "^4.17.11",
     "popper.js": "1.14.6"
   },

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -194,5 +194,41 @@ describe('menu', () => {
     // Mouse over a different parent item.
     await driver.find('.test-cut').mouseMove();
     await assertOpen('.test-submenu1', false);
+    await assertOpen('.test-menu1', true);
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-menu1', false);
+  });
+
+  it('should support setOpenClass() while a menu is open', async function() {
+    // Fixture code sets the default css class (.weasel-popup-open) on the example div
+    // (.test-top), and a custom css class (.custom-menu-open) on <body>.
+    assert.notInclude(await driver.find('.test-top').getAttribute('class'), 'weasel-popup-open');
+    assert.notInclude(await driver.find('body').getAttribute('class'), 'custom-menu-open');
+
+    await driver.find('.test-btn1').click();
+    await assertOpen('.test-menu1', true);
+    assert.include(await driver.find('.test-top').getAttribute('class'), 'weasel-popup-open');
+    assert.include(await driver.find('body').getAttribute('class'), 'custom-menu-open');
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-menu1', false);
+    assert.notInclude(await driver.find('.test-top').getAttribute('class'), 'weasel-popup-open');
+    assert.notInclude(await driver.find('body').getAttribute('class'), 'custom-menu-open');
+  });
+
+  it('should not steal focus set by menu actions', async function() {
+    // First check that open/close leaves the menu-trigger button focused.
+    await driver.find('.test-btn1').click();
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-menu1', false);
+    assert.equal(await driver.find('.test-btn1').hasFocus(), true);
+
+    // Now click the "Focus Reset" menu item which SHOULD focus the Reset button. We are making
+    // sure that focus does NOT get restored to the menu-trigger button if an action changed it.
+    await driver.find('.test-btn1').click();
+    await driver.find('.test-focus-reset').click();
+    await assertOpen('.test-menu1', false);
+    assert.equal(await driver.find('.test-btn1').hasFocus(), false);
+    assert.equal(await driver.find('.test-reset').hasFocus(), true);
   });
 });

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -1,0 +1,198 @@
+import {assert, driver, Key, useServer} from 'mocha-webdriver';
+import {server} from '../fixtures/webpack-test-server';
+
+describe('menu', () => {
+  useServer(server);
+
+  before(async function() {
+    this.timeout(60000);      // Set a longer default timeout.
+    await driver.get(`${server.getHost()}/menu`);
+  });
+
+  beforeEach(async function() {
+    await driver.find('.test-reset').click();
+  });
+
+  async function assertOpen(testId: string, yesNo: boolean) {
+    if (yesNo) {
+      assert.equal(await driver.find(testId).isDisplayed(), yesNo);
+    } else {
+      await assert.isRejected(driver.find(testId), /Unable to locate/);
+    }
+  }
+
+  it('should toggle on trigger click', async function() {
+    // Open menu, check we see something.
+    await driver.find('.test-btn1').click();
+    await assertOpen('.test-menu1', true);
+    assert.equal(await driver.find('.test-copy').getText(), 'Copy');
+
+    // Click again to close.
+    await driver.find('.test-btn1').click();
+    await assertOpen('.test-menu1', false);
+    await assert.isRejected(driver.find('.test-copy'), /Unable to locate/);
+  });
+
+  it('should take action and close on item click unless disabled', async function() {
+    // Open menu.
+    await driver.find('.test-btn1').click();
+    assert.equal(await driver.find('.test-last').getText(), '');
+
+    // Click a disabled item. Menu should stay open, and no action should run.
+    await driver.find('.test-disabled1').click();
+    await assertOpen('.test-menu1', true);
+    assert.equal(await driver.find('.test-last').getText(), '');
+
+    // Click an item. Check that it runs and menu gets closed.
+    await driver.find('.test-copy').click();
+    assert.equal(await driver.find('.test-last').getText(), 'Copy');
+    await assertOpen('.test-menu1', false);
+  });
+
+  it('should close on Escape', async function() {
+    await driver.find('.test-btn1').click();
+    await assertOpen('.test-menu1', true);
+    // Ensure menu closes on Escape.
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-menu1', false);
+  });
+
+  it('should allow navigation and selection with keys', async function() {
+    await driver.find('.test-btn1').click();
+    // Check that focus changes as we navigate.
+    await driver.sendKeys(Key.DOWN);
+    assert.equal(await driver.find('.test-cut').hasFocus(), true);
+    await driver.sendKeys(Key.DOWN);
+    assert.equal(await driver.find('.test-copy').hasFocus(), true);
+    // Navigating toward a disabled element skips to the next enabled one.
+    await driver.sendKeys(Key.DOWN);
+    assert.equal(await driver.find('.test-paste').hasFocus(), true);
+    // Navigating back up also skips the disabled element.
+    await driver.sendKeys(Key.UP);
+    assert.equal(await driver.find('.test-copy').hasFocus(), true);
+
+    // ENTER runs the action and closes.
+    await assertOpen('.test-menu1', true);
+    assert.equal(await driver.find('.test-last').getText(), '');
+    await driver.sendKeys(Key.ENTER);
+    assert.equal(await driver.find('.test-last').getText(), 'Copy');
+    await assertOpen('.test-menu1', false);
+  });
+
+  it('should react to click even if another item is selected', async function() {
+    // Use keys to select an item.
+    await driver.find('.test-btn1').click();
+    await driver.sendKeys(Key.DOWN);
+    await driver.sendKeys(Key.DOWN);
+    assert.equal(await driver.find('.test-copy').hasFocus(), true);
+
+    // Click a different item, ensure the clicked item is the action that runs.
+    await driver.find('.test-cut').click();
+    assert.equal(await driver.find('.test-last').getText(), 'Cut');
+  });
+
+  it('should act on Enter even if item selected with mouseover', async function() {
+    // Move mouse to select an item.
+    await driver.find('.test-btn1').click();
+    await driver.find('.test-copy').mouseMove();
+    assert.equal(await driver.find('.test-copy').hasFocus(), true);
+
+    // Hit Enter to run the action of that item.
+    await driver.sendKeys(Key.ENTER);
+    assert.equal(await driver.find('.test-last').getText(), 'Copy');
+  });
+
+  it('should highlight item on mouseover correctly', async function() {
+    await driver.find('.test-btn1').click();
+    // Moving the mouse over an item focuses (and selects) the item.
+    await driver.find('.test-copy').mouseMove();
+    assert.equal(await driver.find('.test-copy').hasFocus(), true);
+    // Moving the mouse to a divider deselects the item, leaves menu focused.
+    await driver.find('.test-divider1').mouseMove();
+    assert.equal(await driver.find('.test-menu1').hasFocus(), true);
+
+    // Move mouse to select another item.
+    await driver.find('.test-cut').mouseMove();
+    assert.equal(await driver.find('.test-cut').hasFocus(), true);
+    // Moving mouse over a disabled item deselects, leaves menu focused.
+    await driver.find('.test-disabled1').mouseMove();
+    assert.equal(await driver.find('.test-menu1').hasFocus(), true);
+
+    // Move mouse to select an item again.
+    await driver.find('.test-cut').mouseMove();
+    assert.equal(await driver.find('.test-cut').hasFocus(), true);
+    // Moving mouse over body (outside all menus) deselects, leaves menu focused.
+    await driver.find('.test-btn1').mouseMove({x: 0, y: -50});
+    assert.equal(await driver.find('.test-menu1').hasFocus(), true);
+    await driver.withActions((a) => a.click());
+    await assertOpen('.test-menu1', false);
+  });
+
+  it('should open submenu and act on item clicks', async function() {
+    await driver.find('.test-btn1').click();
+    await assertOpen('.test-menu1', true);
+
+    // Mouse over on submenu item opens the submenu.
+    await driver.find('.test-sub-item').mouseMove();
+    await driver.findWait(1, '.test-submenu1');
+    await assertOpen('.test-submenu1', true);
+
+    // Click on an item in the submenu runs the action and closes both menus.
+    await driver.find('.test-copy2').click();
+    assert.equal(await driver.find('.test-last').getText(), 'Copy2');
+    await assertOpen('.test-submenu1', false);
+    await assertOpen('.test-menu1', false);
+  });
+
+  it('should respect keys to open/close/navigate submenu', async function() {
+    // Select the submenu item with keyboard (last item).
+    await driver.find('.test-btn1').click();
+    await driver.sendKeys(Key.UP);
+    assert.equal(await driver.find('.test-sub-item').hasFocus(), true);
+
+    // Enter key should open the submenu.
+    await assertOpen('.test-submenu1', false);
+    await driver.sendKeys(Key.ENTER);
+    await assertOpen('.test-submenu1', true);
+
+    // First non-disabled item should be selected.
+    assert.equal(await driver.find('.test-cut2').hasFocus(), true);
+
+    // LEFT key should close.
+    await driver.sendKeys(Key.LEFT);
+    await assertOpen('.test-submenu1', false);
+    assert.equal(await driver.find('.test-sub-item').hasFocus(), true);
+
+    // RIGHT key should reopen.
+    await driver.sendKeys(Key.RIGHT);
+    await assertOpen('.test-submenu1', true);
+    assert.equal(await driver.find('.test-cut2').hasFocus(), true);
+
+    // UP/DOWN navigate.
+    await driver.sendKeys(Key.DOWN);
+    assert.equal(await driver.find('.test-copy2').hasFocus(), true);
+    await driver.sendKeys(Key.UP, Key.UP);  // Wrap around top.
+    assert.equal(await driver.find('.test-sub-item2').hasFocus(), true);
+    await driver.sendKeys(Key.UP);
+    assert.equal(await driver.find('.test-paste2').hasFocus(), true);
+
+    // ESCAPE should close both menus.
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-submenu1', false);
+    await assertOpen('.test-menu1', false);
+    // No actions were performed.
+    assert.equal(await driver.find('.test-last').getText(), '');
+  });
+
+  it('should close submenu when a different parent item is selected', async function() {
+    // Opent the menu and submenu.
+    await driver.find('.test-btn1').click();
+    await driver.find('.test-sub-item').mouseMove();
+    await driver.findWait(1, '.test-submenu1');
+    await assertOpen('.test-submenu1', true);
+
+    // Mouse over a different parent item.
+    await driver.find('.test-cut').mouseMove();
+    await assertOpen('.test-submenu1', false);
+  });
+});

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -93,7 +93,7 @@ describe('menu', () => {
 
   it('should act on Enter even if item selected with mouseover', async function() {
     // Move mouse to select an item.
-    await driver.find('.test-btn1').click();
+    await driver.find('.test-btn1').mouseMove().click();
     await driver.find('.test-copy').mouseMove();
     assert.equal(await driver.find('.test-copy').hasFocus(), true);
 
@@ -103,7 +103,7 @@ describe('menu', () => {
   });
 
   it('should highlight item on mouseover correctly', async function() {
-    await driver.find('.test-btn1').click();
+    await driver.find('.test-btn1').mouseMove().click();
     // Moving the mouse over an item focuses (and selects) the item.
     await driver.find('.test-copy').mouseMove();
     assert.equal(await driver.find('.test-copy').hasFocus(), true);
@@ -129,7 +129,7 @@ describe('menu', () => {
   });
 
   it('should open submenu and act on item clicks', async function() {
-    await driver.find('.test-btn1').click();
+    await driver.find('.test-btn1').mouseMove().click();
     await assertOpen('.test-menu1', true);
 
     // Mouse over on submenu item opens the submenu.
@@ -186,7 +186,7 @@ describe('menu', () => {
 
   it('should close submenu when a different parent item is selected', async function() {
     // Opent the menu and submenu.
-    await driver.find('.test-btn1').click();
+    await driver.find('.test-btn1').mouseMove().click();
     await driver.find('.test-sub-item').mouseMove();
     await driver.findWait(1, '.test-submenu1');
     await assertOpen('.test-submenu1', true);

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -3,7 +3,7 @@
  */
 // tslint:disable:no-console
 import {dom, DomElementArg, makeTestId, obsArray, observable, styled, TestId} from 'grainjs';
-import {cssMenuDivider, menu, menuItem, menuItemLink, menuItemSubmenu} from '../../index';
+import {cssMenuDivider, IOpenController, menu, menuItem, menuItemLink, menuItemSubmenu} from '../../index';
 
 document.addEventListener('DOMContentLoaded', () => {
   document.body.appendChild(setupTest());
@@ -38,12 +38,14 @@ function setupTest() {
   // differently-positioned tooltps, and we'll check that hovering over each one causes 1 tooltip
   // to flip. We'll also include a body-attached tooltip which should overhang the box.
   return cssExample(testId('top'),
-    dom('button', 'My Menu', menu(makeMenu)),
+    cssButton('My Menu', menu(makeMenu)),
     dom('button', 'My Funky Menu', menu(makeFunkyMenu, funkyOptions))
   );
 }
 
-function makeMenu(): DomElementArg[] {
+function makeMenu(ctl: IOpenController): DomElementArg[] {
+  ctl.setOpenClass(ctl.getTriggerElem().parentElement!);
+
   console.log("makeMenu");
   return [
     menuItem(() => { console.log("Menu item: Cut"); }, "Cut", dom.hide(hideCut)),
@@ -116,5 +118,20 @@ const cssExample = styled('div', `
   & button {
     display: block;
     white-space: nowrap;
+  }
+  &.weasel-popup-open {
+    outline: 1px solid red;
+  }
+`);
+
+const cssButton = styled('div', `
+  width: 100px;
+  border-radius: 3px;
+  background-color: #4444aa;
+  color: white;
+  padding: 8px;
+  margin: 16px;
+  &:hover, &.weasel-popup-open {
+    background-color: #6666cc;
   }
 `);

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -12,7 +12,8 @@ let resetBtn: HTMLElement;
 function setupTest() {
   return cssExample(testId('top'),
     // tabindex makes it focusable, allowing us to test focus restore issues.
-    cssButton('My Menu', menu(makeMenu), testId('btn1'), {tabindex: "-1"}),
+    cssButton('My Menu', menu(makeMenu, {parentSelectorToMark: '.' + cssExample.className}),
+      testId('btn1'), {tabindex: "-1"}),
     cssButton('My Funky Menu', menu(makeFunkyMenu, funkyOptions)),
     dom('div', 'Last action: ',
       dom('span', dom.text(lastAction), testId('last'))
@@ -27,8 +28,7 @@ function makeMenu(ctl: IOpenController): DomElementArg[] {
   const hideCut = observable(false);
   const pasteList = obsArray(['Paste 1']);
 
-  // Set some custom css classes while menu is open.
-  ctl.setOpenClass(ctl.getTriggerElem().parentElement!);
+  // Set a custom css class while menu is open.
   ctl.setOpenClass(document.body, 'custom-menu-open');
 
   console.log("makeMenu");

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -3,7 +3,7 @@
  */
 // tslint:disable:no-console
 import {dom, DomElementArg, makeTestId, obsArray, observable, styled, TestId} from 'grainjs';
-import {cssMenuDivider, menu, menuItem, menuItemSubmenu} from '../../index';
+import {cssMenuDivider, menu, menuItem, menuItemLink, menuItemSubmenu} from '../../index';
 
 document.addEventListener('DOMContentLoaded', () => {
   document.body.appendChild(setupTest());
@@ -54,10 +54,11 @@ function makeMenu(): DomElementArg[] {
       pasteList.push(`Paste ${++pasteCount}`);
     }, "Paste"),
     cssMenuDivider(),
-    dom.forEach(pasteList, str =>
+    dom.forEach(pasteList, (str) =>
       menuItem(() => { console.log(`Menu item: ${str}`); }, str)
     ),
     cssMenuDivider(),
+    menuItemLink({href: 'https://getgrist.com'}, 'Visit getgrist.com'),
     menuItem(() => {
       hideCut.set(!hideCut.get());
       console.log("Menu item: Show/Hide Cut");
@@ -70,7 +71,7 @@ function makeMenu(): DomElementArg[] {
 function makePasteSubmenu(): DomElementArg[] {
   console.log("makePasteSubmenu");
   return [
-    menuItem(() => {}, {class: 'disabled'}, "Disabled"),
+    menuItem(() => { alert("This shouldn't happen"); }, {class: 'disabled'}, "Disabled"),
     menuItem(() => { console.log("Menu item: Cut2"); }, "Cut2"),
     menuItem(() => { console.log("Menu item: Copy2"); }, "Copy2"),
     menuItem(() => { console.log("Menu item: Paste2"); }, "Paste2"),

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -5,79 +5,63 @@
 import {dom, DomElementArg, makeTestId, obsArray, observable, styled, TestId} from 'grainjs';
 import {cssMenuDivider, IOpenController, menu, menuItem, menuItemLink, menuItemSubmenu} from '../../index';
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.body.appendChild(setupTest());
-});
-
 const testId: TestId = makeTestId('test-');
-
-const funkyMenu = styled('div', `
-  font-size: 18px;
-  font-family: serif;
-  background-color: DarkGray;
-  color: white;
-  min-width: 250px;
-  box-shadow: 0 0 10px rgba(0, 0, 100, 0.5);
-  border: 1px solid white;
-
-  --weaseljs-selected-background-color: white;
-  --weaseljs-selected-color: black;
-  --weaseljs-menu-item-padding: 20px;
-`);
-
-const funkyOptions = {
-  menuCssClass: funkyMenu.className,
-};
-
-const hideCut = observable(false);
-const pasteList = obsArray(['Paste 1']);
-let pasteCount: number = 1;
+const lastAction = observable("");
 
 function setupTest() {
-  // Create a rectangle, with a button along each edge. Each botton will have 4
-  // differently-positioned tooltps, and we'll check that hovering over each one causes 1 tooltip
-  // to flip. We'll also include a body-attached tooltip which should overhang the box.
   return cssExample(testId('top'),
-    cssButton('My Menu', menu(makeMenu)),
-    dom('button', 'My Funky Menu', menu(makeFunkyMenu, funkyOptions))
+    cssButton('My Menu', menu(makeMenu), testId('btn1')),
+    cssButton('My Funky Menu', menu(makeFunkyMenu, funkyOptions)),
+    dom('div', 'Last action: ',
+      dom('span', dom.text(lastAction), testId('last'))
+    ),
+    dom('button', 'Reset', dom.on('click', () => lastAction.set('')), testId('reset')),
   );
 }
 
 function makeMenu(ctl: IOpenController): DomElementArg[] {
+  const hideCut = observable(false);
+  const pasteList = obsArray(['Paste 1']);
+
   ctl.setOpenClass(ctl.getTriggerElem().parentElement!);
 
   console.log("makeMenu");
   return [
-    menuItem(() => { console.log("Menu item: Cut"); }, "Cut", dom.hide(hideCut)),
-    menuItemSubmenu(makePasteSubmenu, {}, "Paste Special"),
-    menuItem(() => { console.log("Menu item: Copy"); }, "Copy"),
-    menuItem(() => {
-      console.log("Menu item: Paste");
-      pasteList.push(`Paste ${++pasteCount}`);
-    }, "Paste"),
-    cssMenuDivider(),
-    dom.forEach(pasteList, (str) =>
-      menuItem(() => { console.log(`Menu item: ${str}`); }, str)
+    testId('menu1'),
+    menuItem(() => lastAction.set("Cut"), "Cut", dom.hide(hideCut), testId('cut')),
+    menuItem(() => lastAction.set("Copy"), "Copy", testId('copy')),
+    menuItem(() => lastAction.set("Disabled (should not happen!)"),
+      dom.cls('disabled'), "Disabled", testId('disabled1')
     ),
-    cssMenuDivider(),
-    menuItemLink({href: 'https://getgrist.com'}, 'Visit getgrist.com'),
+    menuItem(() => {
+      lastAction.set("Paste");
+      pasteList.push(`Paste ${pasteList.get().length + 1}`);
+    }, "Paste", testId('paste')),
+    cssMenuDivider(testId('divider1')),
+    dom.forEach(pasteList, (str) =>
+      menuItem(() => lastAction.set(str), str)
+    ),
+    cssMenuDivider(testId('divider2')),
+    menuItemLink({href: 'https://getgrist.com'}, 'Visit getgrist.com', testId('link1')),
     menuItem(() => {
       hideCut.set(!hideCut.get());
-      console.log("Menu item: Show/Hide Cut");
+      lastAction.set("Show/Hide Cut");
     }, dom.text((use) => use(hideCut) ? "Show Cut" : "Hide Cut")),
     cssMenuDivider(),
-    menuItemSubmenu(makePasteSubmenu, {}, "Paste Special"),
+    menuItemSubmenu(makePasteSubmenu, {}, "Paste Special", testId('sub-item')),
   ];
 }
 
 function makePasteSubmenu(): DomElementArg[] {
   console.log("makePasteSubmenu");
   return [
-    menuItem(() => { alert("This shouldn't happen"); }, {class: 'disabled'}, "Disabled"),
-    menuItem(() => { console.log("Menu item: Cut2"); }, "Cut2"),
-    menuItem(() => { console.log("Menu item: Copy2"); }, "Copy2"),
-    menuItem(() => { console.log("Menu item: Paste2"); }, "Paste2"),
-    menuItemSubmenu(makePasteSubmenu, {}, "Paste Special2"),
+    testId('submenu1'),
+    menuItem(() => lastAction.set('Disabled (should not happen!)'), "Disabled",
+      {class: 'disabled'}, testId('disabled2')),
+    menuItem(() => lastAction.set('Cut2'), "Cut2", testId('cut2')),
+    menuItem(() => lastAction.set('Copy2'), "Copy2", testId('copy2')),
+    menuItem(() => lastAction.set('Paste2'), "Paste2", testId('paste2')),
+    menuItemSubmenu(makePasteSubmenu, {}, "Paste Special2", testId('sub-item2')),
   ];
 }
 
@@ -114,6 +98,7 @@ const cssExample = styled('div', `
   vertical-align: baseline;
   height: 300px;
   width: 500px;
+  padding: 16px;
 
   & button {
     display: block;
@@ -126,12 +111,35 @@ const cssExample = styled('div', `
 
 const cssButton = styled('div', `
   width: 100px;
+  font-size: 13px;
   border-radius: 3px;
   background-color: #4444aa;
   color: white;
   padding: 8px;
-  margin: 16px;
+  margin: 16px 0px;
   &:hover, &.weasel-popup-open {
     background-color: #6666cc;
   }
 `);
+
+const cssFunkyMenu = styled('div', `
+  font-size: 18px;
+  font-family: serif;
+  background-color: DarkGray;
+  color: white;
+  min-width: 250px;
+  box-shadow: 0 0 10px rgba(0, 0, 100, 0.5);
+  border: 1px solid white;
+
+  --weaseljs-selected-background-color: white;
+  --weaseljs-selected-color: black;
+  --weaseljs-menu-item-padding: 20px;
+`);
+
+const funkyOptions = {
+  menuCssClass: cssFunkyMenu.className,
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.body.appendChild(setupTest());
+});

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -7,15 +7,19 @@ import {cssMenuDivider, IOpenController, menu, menuItem, menuItemLink, menuItemS
 
 const testId: TestId = makeTestId('test-');
 const lastAction = observable("");
+let resetBtn: HTMLElement;
 
 function setupTest() {
   return cssExample(testId('top'),
-    cssButton('My Menu', menu(makeMenu), testId('btn1')),
+    // tabindex makes it focusable, allowing us to test focus restore issues.
+    cssButton('My Menu', menu(makeMenu), testId('btn1'), {tabindex: "-1"}),
     cssButton('My Funky Menu', menu(makeFunkyMenu, funkyOptions)),
     dom('div', 'Last action: ',
       dom('span', dom.text(lastAction), testId('last'))
     ),
-    dom('button', 'Reset', dom.on('click', () => lastAction.set('')), testId('reset')),
+    resetBtn = cssResetButton('Reset',
+      dom.on('click', () => lastAction.set('')), testId('reset')
+    ),
   );
 }
 
@@ -23,7 +27,9 @@ function makeMenu(ctl: IOpenController): DomElementArg[] {
   const hideCut = observable(false);
   const pasteList = obsArray(['Paste 1']);
 
+  // Set some custom css classes while menu is open.
   ctl.setOpenClass(ctl.getTriggerElem().parentElement!);
+  ctl.setOpenClass(document.body, 'custom-menu-open');
 
   console.log("makeMenu");
   return [
@@ -47,6 +53,7 @@ function makeMenu(ctl: IOpenController): DomElementArg[] {
       hideCut.set(!hideCut.get());
       lastAction.set("Show/Hide Cut");
     }, dom.text((use) => use(hideCut) ? "Show Cut" : "Hide Cut")),
+    menuItem(() => resetBtn.focus(), 'Focus Reset', testId('focus-reset')),
     cssMenuDivider(),
     menuItemSubmenu(makePasteSubmenu, {}, "Paste Special", testId('sub-item')),
   ];
@@ -119,6 +126,12 @@ const cssButton = styled('div', `
   margin: 16px 0px;
   &:hover, &.weasel-popup-open {
     background-color: #6666cc;
+  }
+`);
+
+const cssResetButton = styled('button', `
+  &:focus {
+    outline: 3px solid yellow;
   }
 `);
 

--- a/test/fixtures/template.html
+++ b/test/fixtures/template.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf8">
-    <link rel="stylesheet" href="icons.css">
   </head>
   <body>
     <script src='build/<NAME>.bundle.js'></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,9 +2209,9 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-"grainjs@git+https://github.com/gristlabs/grainjs.git#44d563adbab3730bd116cbbff73ee9842b289a53":
+"grainjs@git+https://github.com/gristlabs/grainjs.git#3d884cd7e7c10cd1c5179a605035a59aa8eab0d0":
   version "0.1.1"
-  resolved "git+https://github.com/gristlabs/grainjs.git#44d563adbab3730bd116cbbff73ee9842b289a53"
+  resolved "git+https://github.com/gristlabs/grainjs.git#3d884cd7e7c10cd1c5179a605035a59aa8eab0d0"
 
 growl@1.10.5:
   version "1.10.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,10 +3290,10 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mocha-webdriver@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/mocha-webdriver/-/mocha-webdriver-0.1.6.tgz#aa4b6640c19a569d28028ff8464a734a8f6640cd"
-  integrity sha512-cd8T30PfidYry030xVNhGSo4YZyLyda8RBZKp5md06Fqh0fmJbHPhKAXLE/oGn0jw2ikmHgZhCjhNaSTffdvlw==
+mocha-webdriver@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/mocha-webdriver/-/mocha-webdriver-0.1.7.tgz#d38e25ca371b14a393fc86825cf8fd4ac5aa93ce"
+  integrity sha512-N4xAoe/vtMWCt1fMeV5x9Hlvmb0wqa2e2ykJ3fzC5bnFZ4uJ3sYoT/DuZZRiQIRpwr2TIxmr2FUhv6pMbt5M6Q==
   dependencies:
     chai "^4.1.2"
     chai-as-promised "^7.1.1"


### PR DESCRIPTION
This includes a number of fixes and updates.
- Adds a fairly comprehensive browser test of menu functionality.
- Big difference is what the `ctl` object is when a popup is opened: it is now a temporary object that's disposed on close, so popup creator function may use ctl.onDispose() & co.
- Added method ctl.getTriggerElem() for the trigger element that opened this popup.
- Added method ctl.setOpenClass(elem) to set a css class on an element while popup is open.
- Automatically set `weasel-popup-open` css class on trigger element while popup is open.
- Adds `menuItemLink()` for `<a href>` menu items.
- Supports optional onRemove() method in PopupContent, used by menus to restore focus without interfering with intentional focus changes. (This should address the focus problems that require setTimeout() workarounds.)
- Deselects items when they are not hovered.
- Changes `startIndex` option to `selectOnOpen` option which slightly simplifies code (only used by submenus, i.e. essentially it's an implementation detail)
- Fixes a number of issues discovered when writing the test.