### PR TITLE
Fix issue when placement is omitted, using popper's own default of 'bottom'

### DIFF
--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -274,7 +274,7 @@ class OpenPopupHelper extends Disposable {
 
     // Prepare and create the Popper instance, which places the content according to the options.
     const popperOptions: Popper.PopperOptions = {
-      placement: options.placement,
+      placement: options.placement || 'bottom',
       modifiers: (options.boundaries ?
         defaultsDeep(options.modifiers, {
           flip: {boundariesElement: options.boundaries},


### PR DESCRIPTION
It turns out while popper accepts a `placement` missing from its options, it doesn't like `placement` of `undefined`, so we need to avoid that.