### PR TITLE
Add contextmenu trigger

### DIFF
--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -187,6 +187,8 @@ export class PopupControl<T extends IPopupOptions = IPopupOptions> extends Dispo
                 ev.preventDefault(); // Prevent the default browser contextmenu behavior
                 this.open();
               });
+              // Popups are usually closed by a click outside of triggerElem and popup content,
+              // but in this case we want clicks on triggerElem to close as well.
               dom.onElem(triggerElem, 'click', () => this.close());
               break;
             case 'focus':

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -8,7 +8,7 @@ import Popper from 'popper.js';
  * On what event the trigger element opens the popup. E.g. 'hover' is suitable for a tooltip,
  * while 'click' is suitable for a dropdown menu.
  */
-type Trigger  = 'click' | 'hover' | 'focus' | AttachTriggerFunc;
+type Trigger  = 'click' | 'contextmenu' |  'hover' | 'focus' | AttachTriggerFunc;
 
 /**
  * AttachTriggerFunc allows setting custom trigger events in a callback function to toggle the
@@ -181,6 +181,13 @@ export class PopupControl<T extends IPopupOptions = IPopupOptions> extends Dispo
           switch (trigger) {
             case 'click':
               dom.onElem(triggerElem, 'click', () => this.toggle());
+              break;
+            case 'contextmenu':
+              dom.onElem(triggerElem, 'contextmenu', (ev) => {
+                ev.preventDefault(); // Prevent the default browser contextmenu behavior
+                this.open();
+              });
+              dom.onElem(triggerElem, 'click', () => this.close());
               break;
             case 'focus':
               dom.onElem(triggerElem, 'focus', () => this.open());

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.3",
-    "@types/selenium-webdriver": "^3.0.13",
+    "@types/selenium-webdriver": "^4.0.0",
     "@types/webpack-merge": "^4.1.3",
     "@types/webpack-serve": "^2.0.0",
     "cache-loader": "^1.2.5",

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -36,12 +36,13 @@ describe('menu', () => {
   it('should open on contextmenu', async function() {
     // Open contextmenu, check we see something.
     const btn = await driver.find('.test-btn2');
-    await driver.actions().contextClick(btn).perform();
+    const actions = driver.actions({bridge: true});
+    await actions.contextClick(btn).perform();
     await assertOpen('.test-menu1', true);
     assert.equal(await driver.find('.test-copy').getText(), 'Copy');
 
     // Open contextmenu again, should reopen
-    await driver.actions().contextClick(btn).perform();
+    await actions.contextClick(btn).perform();
     await assertOpen('.test-menu1', true);
     assert.equal(await driver.find('.test-copy').getText(), 'Copy');
 

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -33,6 +33,24 @@ describe('menu', () => {
     await assert.isRejected(driver.find('.test-copy'), /Unable to locate/);
   });
 
+  it('should open on contextmenu', async function() {
+    // Open contextmenu, check we see something.
+    const btn = await driver.find('.test-btn2');
+    await driver.actions().contextClick(btn).perform();
+    await assertOpen('.test-menu1', true);
+    assert.equal(await driver.find('.test-copy').getText(), 'Copy');
+
+    // Open contextmenu again, should reopen
+    await driver.actions().contextClick(btn).perform();
+    await assertOpen('.test-menu1', true);
+    assert.equal(await driver.find('.test-copy').getText(), 'Copy');
+
+    // Click element, should close
+    await btn.click();
+    await assertOpen('.test-menu1', false);
+    await assert.isRejected(driver.find('.test-copy'), /Unable to locate/);
+  });
+
   it('should take action and close on item click unless disabled', async function() {
     // Open menu.
     await driver.find('.test-btn1').click();

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -36,13 +36,12 @@ describe('menu', () => {
   it('should open on contextmenu', async function() {
     // Open contextmenu, check we see something.
     const btn = await driver.find('.test-btn2');
-    const actions = driver.actions({bridge: true});
-    await actions.contextClick(btn).perform();
+    await driver.withActions((a: any) => a.contextClick(btn));
     await assertOpen('.test-menu1', true);
     assert.equal(await driver.find('.test-copy').getText(), 'Copy');
 
     // Open contextmenu again, should reopen
-    await actions.contextClick(btn).perform();
+    await driver.withActions((a: any) => a.contextClick(btn));
     await assertOpen('.test-menu1', true);
     assert.equal(await driver.find('.test-copy').getText(), 'Copy');
 

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -26,13 +26,19 @@ function setupTest() {
 
   return cssExample(testId('top'),
     // tabindex makes it focusable, allowing us to test focus restore issues.
-    cssButton('My Menu', menu(makeMenu, {parentSelectorToMark: '.' + cssExample.className}),
-      testId('btn1'), {tabindex: "-1"}),
-    cssButton('My Contextmenu', menu(makeMenu, {
-      trigger: ['contextmenu'],
-      parentSelectorToMark: '.' + cssExample.className
-    }),
-      testId('btn2'), {tabindex: "-1"}),
+    cssButton('My Menu',
+      testId('btn1'),
+      { tabindex: "-1" },
+      menu(makeMenu, { parentSelectorToMark: '.' + cssExample.className })
+    ),
+    cssButton('My Contextmenu',
+      testId('btn2'),
+      { tabindex: "-1" },
+      menu(makeMenu, {
+        trigger: ['contextmenu'],
+        parentSelectorToMark: '.' + cssExample.className
+      })
+    ),
     cssButton('My Funky Menu', menu(makeFunkyMenu, funkyOptions)),
     cssInputContainer(
       cssInput(inputObs, {onInput: true}, {placeholder: 'My Input Menu'},

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -3,7 +3,8 @@
  */
 // tslint:disable:no-console
 import {dom, DomElementArg, input, makeTestId, obsArray, observable, styled, TestId} from 'grainjs';
-import {cssMenuDivider, IOpenController, menu, menuItem, menuItemLink, menuItemSubmenu} from '../../index';
+import {cssMenuDivider, menu, menuItem, menuItemLink, menuItemSubmenu} from '../../index';
+import {IOpenController, PopupControl} from '../../index';
 import {select} from '../../index';
 
 const testId: TestId = makeTestId('test-');
@@ -15,18 +16,23 @@ function setupTest() {
   function submitInput() {
     console.log("Enter key triggered on input");
     inputObs.set("");
-  };
+  }
   // Triggers the input menu on 'input' events, if the input has text inside.
   function inputTrigger(triggerElem: Element, ctl: PopupControl): void {
     dom.onElem(triggerElem, 'input', () => {
-      triggerElem.value.length > 0 ? ctl.open() : ctl.close();
+      (triggerElem as HTMLInputElement).value.length > 0 ? ctl.open() : ctl.close();
     });
-  };
+  }
 
   return cssExample(testId('top'),
     // tabindex makes it focusable, allowing us to test focus restore issues.
     cssButton('My Menu', menu(makeMenu, {parentSelectorToMark: '.' + cssExample.className}),
       testId('btn1'), {tabindex: "-1"}),
+    cssButton('My Contextmenu', menu(makeMenu, {
+      trigger: ['contextmenu'],
+      parentSelectorToMark: '.' + cssExample.className
+    }),
+      testId('btn2'), {tabindex: "-1"}),
     cssButton('My Funky Menu', menu(makeFunkyMenu, funkyOptions)),
     cssInputContainer(
       cssInput(inputObs, {onInput: true}, {placeholder: 'My Input Menu'},
@@ -117,7 +123,7 @@ function makeInputMenu(): DomElementArg[] {
   console.log("makeInputMenu");
   return [
     testId('input1-menu'),
-    menuItem(() => { console.log(`Menu item: ${inputObs.get()}`)},
+    menuItem(() => { console.log(`Menu item: ${inputObs.get()}`); },
       dom.text((use) => `Log "${use(inputObs)}"`),
       testId('input1-menu-item')
     )
@@ -183,17 +189,17 @@ const cssFunkyMenu = styled('div', `
 const cssInputContainer = styled('div', `
   position: relative;
   width: 400px;
-`)
+`);
 
 const cssInput = styled(input, `
   width: 100%;
   height: 20px;
   margin: 0 0 16px 0;
-`)
+`);
 
 const cssInputMenu = styled('div', `
   min-width: 100%;
-`)
+`);
 
 const funkyOptions = {
   menuCssClass: cssFunkyMenu.className,

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,10 +161,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/selenium-webdriver@^3.0.13":
-  version "3.0.14"
-  resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.14.tgz#0b20a2370e6b1b8322c9c3dfcaa409e6c7c0c0a9"
-  integrity sha512-4GbNCDs98uHCT/OMv40qQC/OpoPbYn9XdXeTiFwHBBFO6eJhYEPUu2zDKirXSbHlvDV8oZ9l8EQ+HrEx/YS9DQ==
+"@types/selenium-webdriver@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-4.0.0.tgz#21aa550f08d2cca49f8537f6697288a0d4300f28"
+  integrity sha512-x/OwFhZaZBkucIl/SuooCmkdu1V6LBfHcBeBV5rj05Co8EenuL1KJiIRUU/Da2hscoqbXyF3QuWDOZZ4sLVA5Q==
 
 "@types/serve-static@*":
   version "1.13.2"


### PR DESCRIPTION
Add support to trigger menu open on contextmenu click (i.e. right click). Subsequent contextmenu clicks open the menu. Clicking on the element closes the menu (just as clicking anywhere else does).

Added tests to mimic `click` ones.

Had to upgrade `@types/selenium-webdriver` to ^4.0.0 to include typings for `driver.contextClick()`.