### PR TITLE
Improve menus to be scrollable, and support keyboard triggers.

### DIFF
--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -299,6 +299,8 @@ function isSelectable(elem: Element): elem is HTMLElement {
  * Whether the given element is part of a selectable item. A click on it will close menus.
  */
 function isInSelectableItem(elem: Element): boolean {
+  // Similar to _findTargetItem, but finds the menu item (direct child of cssMenu) containing
+  // elem, regardless of which menu or submenu it's in, and returns whether it's selectable.
   const item = findAncestorChild(elem.closest('.' + cssMenu.className)!, elem);
   return item ? isSelectable(item) : false;
 }

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -8,7 +8,7 @@ import Popper from 'popper.js';
  * On what event the trigger element opens the popup. E.g. 'hover' is suitable for a tooltip,
  * while 'click' is suitable for a dropdown menu.
  */
-type Trigger  = 'click' | 'contextmenu' |  'hover' | 'focus' | AttachTriggerFunc;
+type Trigger  = 'click' | 'contextmenu' |  'hover' | 'focus' | {keys: string[]} | AttachTriggerFunc;
 
 /**
  * AttachTriggerFunc allows setting custom trigger events in a callback function to toggle the
@@ -177,6 +177,8 @@ export class PopupControl<T extends IPopupOptions = IPopupOptions> extends Dispo
         if (typeof trigger === 'function') {
           // Call instances of AttachTriggerFunc to attach any custom trigger events.
           trigger(triggerElem, this);
+        } else if (typeof trigger === "object" && "keys" in trigger) {
+          dom.onElem(triggerElem, 'keydown', (ev) => trigger.keys.includes(ev.key) && this.toggle());
         } else {
           switch (trigger) {
             case 'click':

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/gristlabs/weasel.js#readme",
   "dependencies": {
-    "grainjs": "^1.0.0",
-    "lodash": "^4.17.11",
+    "grainjs": "^1.0.1",
+    "lodash": "^4.17.15",
     "popper.js": "1.15.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "dist/index",
   "scripts": {
     "build": "tsc",
-    "test": "mocha 'test/browser/**/*.{js,ts}'",
-    "test-debug": "mocha --bail test/browser/**/*.{js,ts} --no-exit",
+    "test": "MOCHA_WEBDRIVER_STACKTRACES=1 mocha 'test/browser/**/*.{js,ts}'",
+    "test-debug": "MOCHA_WEBDRIVER_STACKTRACES=1 mocha --bail test/browser/**/*.{js,ts} --no-exit",
     "test-manual": "webpack-dev-server --config test/fixtures/webpack.config.js",
     "prepack": "npm run build && npm test"
   },

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -30,7 +30,10 @@ function setupTest() {
     cssButton('My Menu',
       testId('btn1'),
       { tabindex: "-1" },
-      menu(makeMenu, { parentSelectorToMark: '.' + cssExample.className })
+      menu(makeMenu, {
+        parentSelectorToMark: '.' + cssExample.className,
+        trigger: ['click', {keys: ['Enter']}],
+      })
     ),
     cssButton('My Contextmenu',
       testId('btn2'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2072,10 +2072,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-grainjs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/grainjs/-/grainjs-1.0.0.tgz#52163f3db6e294c444936395cc2099fd9bf069f5"
-  integrity sha512-PMG0HFJFKbCND+hAHrMPHSiwoum0G4lZvuRkdTx2WgoOtq3UY8ODReNP0qWST7woRkT0uSv4Ix/jNJBr8Zgtaw==
+grainjs@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/grainjs/-/grainjs-1.0.1.tgz#2eb7e1a628e550de1dcbe3f97358d28e4dbefff8"
+  integrity sha512-N5odOGRDsdKYs+M+WAtmlACuRZh60vKzzXhxCcWfRftriRCilWnLIowNNU0siFzex2qauK5i7YV3dZ3lXA1w7A==
 
 growl@1.10.5:
   version "1.10.5"
@@ -2793,10 +2793,10 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+lodash@^4.17.11, lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
- An extra wrapper is added to menus, with the internal part scrollable,
  and the outer part containing submenus.
- The default 'attach' option is changed to attach to the outer wrapper.
- Event handlers are divided between these based on whether they need to
  handle bubbled events from submenus.
- An issue is addressed to avoid selecting an item that appears under
  the mouse cursor until the cursor is moved. It's separated and desired
  for different reasons, but came out in a test change, so the fix is
  included here.
- Triggers may now include e.g. {keys: ['Enter', 'ArrowDown']} to
  support keyboard when the trigger has focus.

All existing tests pass, but changed behavior (scrolling, keyboard triggers, and mouseover change) are only tested manually.