### PR TITLE
Fix disposal error

### DIFF
--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -310,7 +310,10 @@ class OpenPopupHelper extends Disposable {
   /**
    * Closes the popup. Uses a default delay if delayMs is omitted.
    */
-  public close(delayMs?: number) { this._ctl.close(delayMs); }
+  public close(delayMs?: number) {
+    // Check that the popup controller has not already been disposed.
+    if (this._ctl) { this._ctl.close(delayMs); }
+  }
 
   /**
    * Sets css class `cls` on elem while this popup is open, defaulting to "weasel-popup-open".

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -311,8 +311,7 @@ class OpenPopupHelper extends Disposable {
    * Closes the popup. Uses a default delay if delayMs is omitted.
    */
   public close(delayMs?: number) {
-    // Check that the popup controller has not already been disposed.
-    if (this._ctl) { this._ctl.close(delayMs); }
+    if (!this.isDisposed()) { this._ctl.close(delayMs); }
   }
 
   /**


### PR DESCRIPTION
If a select dropdown is disposed on value change, the popup helper close function may throw an error because the popup controller is already disposed