### PR TITLE
Fix select button text overflow

### DIFF
--- a/lib/select.ts
+++ b/lib/select.ts
@@ -71,7 +71,9 @@ export function select<T>(
     cssBtnText(
       dom.domComputed(selected, sel => renderOption(sel))
     ),
-    options.buttonArrow,
+    dom('div', {style: 'flex: none;'},
+      options.buttonArrow
+    ),
     dom.on('keydown', (ev) => {
       if (isDisabled()) { return; }
       const sel = keyState.add(ev.key);
@@ -207,9 +209,8 @@ export function getOptionFull<T>(option: IOption<T>): IOptionFull<T> {
   return (typeof option === "string") ? {value: option, label: option} : (option as IOptionFull<T>);
 }
 
-// Prevents select button text overflow - assumes buttonArrow width is ~20% of button.
+// Prevents select button text overflow.
 const cssBtnText = styled('div', `
-  width: 80%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -217,6 +218,8 @@ const cssBtnText = styled('div', `
 
 const cssSelectBtn = styled('div', `
   position: relative;
+  display: flex;
+  justify-content: space-between;
   width: 100%;
   height: 30px;
   line-height: 30px;
@@ -226,7 +229,6 @@ const cssSelectBtn = styled('div', `
   border: 1px solid grey;
   border-radius: 3px;
   cursor: pointer;
-  display: flex;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/lib/select.ts
+++ b/lib/select.ts
@@ -68,7 +68,9 @@ export function select<T>(
   const selectBtn: Element = cssSelectBtn({tabIndex: '0', class: options.buttonCssClass || ''},
     dom.autoDispose(selected),
     options.disabled ? dom.cls('disabled', options.disabled) : null,
-    dom.domComputed(selected, sel => renderOption(sel)),
+    cssBtnText(
+      dom.domComputed(selected, sel => renderOption(sel))
+    ),
     options.buttonArrow,
     dom.on('keydown', (ev) => {
       if (isDisabled()) { return; }
@@ -204,6 +206,14 @@ class SelectKeyState<T> {
 export function getOptionFull<T>(option: IOption<T>): IOptionFull<T> {
   return (typeof option === "string") ? {value: option, label: option} : (option as IOptionFull<T>);
 }
+
+// Prevents select button text overflow - assumes buttonArrow width is ~20% of button.
+const cssBtnText = styled('div', `
+  width: 80%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`);
 
 const cssSelectBtn = styled('div', `
   position: relative;

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -18,7 +18,8 @@ const employees = observable([
   {value: 17, label: "Alice"},
   {value: 13, label: "Amy"},
   {value: 21, label: "Eve"},
-  {value: 19, label: "James"}
+  {value: 19, label: "James"},
+  {value: 18, label: "Wolfeschlegelsteinhausenbergerdorff"}
 ]);
 
 function setupTest() {

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -162,7 +162,7 @@ function makeComplexSelect() {
     defaultLabel: "Employee:",
     menuCssClass: cssSelectMenu.className,
     buttonCssClass: cssSelectBtn.className,
-    buttonArrow: dom('div', {style: `position: absolute; right: 10px`}, 'v'),
+    buttonArrow: dom('div', {style: `margin: 0 5px;`}, 'v'),
     disabled: disableSelect
   });
 }


### PR DESCRIPTION
Long text values would overflow the closed select button - now uses ellipsis when the value is too long