### PR TITLE
Change autocomplete to match new desired behaviour

### DIFF
--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -158,6 +158,14 @@ export class PopupControl<T extends IPopupOptions = IPopupOptions> extends Dispo
   private _showDelay: number = 0;
   private _hideDelay: number = 0;
 
+  constructor() {
+    super();
+    this.onDispose(() => {
+      if (this._openTimer !== undefined) { clearTimeout(this._openTimer); }
+      if (this._closeTimer !== undefined) { clearTimeout(this._closeTimer); }
+    });
+  }
+
   public attachElem(triggerElem: Element, openFunc: IPopupFunc<T>, options: T): void {
     this._showDelay = options.showDelay || 0;
     this._hideDelay = options.hideDelay || 0;

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -160,9 +160,11 @@ export class PopupControl<T extends IPopupOptions = IPopupOptions> extends Dispo
 
   constructor() {
     super();
+    // Clear timeouts on disposal, which might still be scheduled and cause JS errors in case of
+    // quick open/close/open interactions
     this.onDispose(() => {
-      if (this._openTimer !== undefined) { clearTimeout(this._openTimer); }
-      if (this._closeTimer !== undefined) { clearTimeout(this._closeTimer); }
+      if (this._openTimer) { clearTimeout(this._openTimer); }
+      if (this._closeTimer) { clearTimeout(this._closeTimer); }
     });
   }
 


### PR DESCRIPTION
This commit brings several changes to autocomplete to implement the new desired behaviour for the choice editor in Grist. 
  * Unselect item when textbox is empty
  * Single escape should close cell entirely
  * Adds `allowNothingSelected` option to Allow up/down to move to "nothing selected" and show last as typed value in textbox
   * Adds `updateOnSelect` option to update the value when moving with up/down or when overing an item with the mouse.
   * Fixes an issues with opening that was happening when holding the enter key down on a column of choices.
   * Remove `contentFunc` options as Grist is the only usage with have so far it is not clear whether this level of customization is needed.

Below is how to instanciate the autocomplete in for the choice editor in Grist.
```
function ChoiceEditor(options) {
  TextEditor.call(this, options);
  ...
    autocomplete(this.textInput, this.choices, {
      updateOnSelect: true,
      allowNothingSelected: true,
      onClick: () => this.options.commands.fieldEditSave(),
    });
```

TODO: features that we want that are still future work:
   * ability to show a dropown icon over the input element.
