### PR TITLE
Adds `popupOpen` interface

### DIFF
--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -99,11 +99,11 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
  *    --weaseljs-selected-color
  *    --weaseljs-menu-item-padding
  */
-export function menuItem(action: () => void, ...args: DomElementArg[]): Element {
+export function menuItem(action: (item: Element) => void, ...args: DomElementArg[]): Element {
   return cssMenuItem(
     ...args,
-    dom.on('click', (ev, elem) => elem.classList.contains('disabled') || action()),
-    onKeyDown({Enter$: action})
+    dom.on('click', (ev, elem) => elem.classList.contains('disabled') || action(elem)),
+    onKeyDown({Enter$: (ev, elem) => action(elem)})
   );
 }
 

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -99,7 +99,7 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
  *    --weaseljs-selected-color
  *    --weaseljs-menu-item-padding
  */
-export function menuItem(action: (item: Element) => void, ...args: DomElementArg[]): Element {
+export function menuItem(action: (item: HTMLElement) => void, ...args: DomElementArg[]): Element {
   return cssMenuItem(
     ...args,
     dom.on('click', (ev, elem) => elem.classList.contains('disabled') || action(elem)),

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -171,10 +171,9 @@ export function popupOpen(reference: Element, domCreator: IPopupDomCreator, opti
     // the click.
     attach: 'body',
 
-    // When using within a menu item, the Popper's default options for
-    // modifiers.flip.boundariesElement and modifiers.preventOverflow.boundariesElement causes the
-    // popup to gets disposed right after the click. Setting boundaries to 'viewport' prevent that
-    // issue.
+    // The Popper's default of 'scrollParent' for modifiers.preventOverflow.boundariesElement causes
+    // the popup to be placed incorrectly when the reference element gets disposed after the
+    // click. Setting boundaries to 'viewport' solves that issue
     boundaries: 'viewport',
   });
 

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -71,6 +71,11 @@ export interface IOpenController extends Disposable {
    */
   getTriggerElem(): Element;
 
+  /**
+   * Schedules an UI update for the popup's position.
+   */
+  update(): void;
+
   // Note that .autoDispose() and .onDispose() methods from grainjs Disposable are available,
   // and triggered when the popup is closed.
 }
@@ -140,6 +145,25 @@ export function setPopupToCreateDom(triggerElem: Element, domCreator: IPopupDomC
     return {content, dispose};
   }
   return setPopupToFunc(triggerElem, openFunc, options);
+}
+
+/**
+ * Open a popup using as content the element returned by the given func.
+ */
+export function popupOpen(reference: Element, domCreator: IPopupDomCreator, options: IPopupOptions): PopupControl {
+  function openFunc(openCtl: IOpenController) {
+    const content = domCreator(openCtl);
+    function dispose() { domDispose(content); ctl.dispose(); }
+    return {content, dispose};
+  }
+  const ctl = PopupControl.create(null) as PopupControl;
+  ctl.attachElem(reference, openFunc, {
+    ...options,
+    // Overrides '.trigger' to avoid attaching listeners to reference.
+    trigger: undefined
+  });
+  ctl.open();
+  return ctl;
 }
 
 // Helper type for maintaining setTimeout() timers.

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -148,7 +148,12 @@ export function setPopupToCreateDom(triggerElem: Element, domCreator: IPopupDomC
 }
 
 /**
- * Open a popup using as content the element returned by the given func.
+ * Open a popup using as content the element returned by the given func. Note that the `trigger`
+ * option is ignored by this function and that the default of the `attach` option is `body` instead of `null`.
+ *
+ * It allows you to bind the creation of the popup to a menu item as follow:
+ *   menuItem(elem => popupOpen(elem, (ctl) => buildDom(ctl)))
+ *
  */
 export function popupOpen(reference: Element, domCreator: IPopupDomCreator, options: IPopupOptions): PopupControl {
   function openFunc(openCtl: IOpenController) {
@@ -157,6 +162,13 @@ export function popupOpen(reference: Element, domCreator: IPopupDomCreator, opti
     return {content, dispose};
   }
   const ctl = PopupControl.create(null) as PopupControl;
+
+  // Set the default for the attach option to `body`. Because otherwise the default 'null' would
+  // causes the popup to be attached to reference.parentNode. This does make little sense when used
+  // as follow `menuItem((elem) => popupOpen(elem, ...` because it would close the popup just after
+  // the click.
+  options = defaultsDeep(options, {attach: 'body'});
+
   ctl.attachElem(reference, openFunc, {
     ...options,
     // Overrides '.trigger' to avoid attaching listeners to reference.
@@ -195,6 +207,10 @@ export class PopupControl<T extends IPopupOptions = IPopupOptions> extends Dispo
   public attachElem(triggerElem: Element, openFunc: IPopupFunc<T>, options: T): void {
     this._showDelay = options.showDelay || 0;
     this._hideDelay = options.hideDelay || 0;
+
+    // Set default for the `boundaries` option to `viewport` to match the description of
+    // IPopupOptions.attach.
+    options = defaultsDeep(options, { boundaries: 'viewport' });
 
     this._open = (openOptions: IPopupOptions) => {
       this._openTimer = undefined;

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -27,9 +27,9 @@ export interface IPopupOptions {
   // default; string is a selector for the closest matching ancestor of triggerElem, e.g. 'body'.
   attach?: Element|string|null;
 
-  // Boundaries for the placement of the popup. The default is 'viewport'. This determines the
-  // values of modifiers.flip.boundariesElement and modifiers.preventOverflow.boundariesElement.
-  // Use null to use the defaults from popper.js. These may be set individually via modifiers.
+  // Boundaries for the placement of the popup. This determines the values of
+  // modifiers.flip.boundariesElement and modifiers.preventOverflow.boundariesElement. Use null to
+  // use the defaults from popper.js. These may be set individually via modifiers.
   boundaries?: Element|'scrollParent'|'window'|'viewport'|null;
 
   // On what events, the popup is triggered.
@@ -163,11 +163,20 @@ export function popupOpen(reference: Element, domCreator: IPopupDomCreator, opti
   }
   const ctl = PopupControl.create(null) as PopupControl;
 
-  // Set the default for the attach option to `body`. Because otherwise the default 'null' would
-  // causes the popup to be attached to reference.parentNode. This does make little sense when used
-  // as follow `menuItem((elem) => popupOpen(elem, ...` because it would close the popup just after
-  // the click.
-  options = defaultsDeep(options, {attach: 'body'});
+  options = defaultsDeep(options, {
+
+    // Set the default for the attach option to `body`. Because otherwise the default 'null' would
+    // causes the popup to be attached to reference.parentNode. This does make little sense when used
+    // as follow `menuItem((elem) => popupOpen(elem, ...` because it would close the popup just after
+    // the click.
+    attach: 'body',
+
+    // When using within a menu item, the Popper's default options for
+    // modifiers.flip.boundariesElement and modifiers.preventOverflow.boundariesElement causes the
+    // popup to gets disposed right after the click. Setting boundaries to 'viewport' prevent that
+    // issue.
+    boundaries: 'viewport',
+  });
 
   ctl.attachElem(reference, openFunc, {
     ...options,
@@ -207,10 +216,6 @@ export class PopupControl<T extends IPopupOptions = IPopupOptions> extends Dispo
   public attachElem(triggerElem: Element, openFunc: IPopupFunc<T>, options: T): void {
     this._showDelay = options.showDelay || 0;
     this._hideDelay = options.hideDelay || 0;
-
-    // Set default for the `boundaries` option to `viewport` to match the description of
-    // IPopupOptions.attach.
-    options = defaultsDeep(options, { boundaries: 'viewport' });
 
     this._open = (openOptions: IPopupOptions) => {
       this._openTimer = undefined;

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -163,7 +163,7 @@ export function popupOpen(reference: Element, domCreator: IPopupDomCreator, opti
   }
   const ctl = PopupControl.create(null) as PopupControl;
 
-  options = defaultsDeep(options, {
+  ctl.attachElem(reference, openFunc, {
 
     // Set the default for the attach option to `body`. Because otherwise the default 'null' would
     // causes the popup to be attached to reference.parentNode. This does make little sense when used
@@ -175,10 +175,9 @@ export function popupOpen(reference: Element, domCreator: IPopupDomCreator, opti
     // the popup to be placed incorrectly when the reference element gets disposed after the
     // click. Setting boundaries to 'viewport' solves that issue
     boundaries: 'viewport',
-  });
 
-  ctl.attachElem(reference, openFunc, {
     ...options,
+
     // Overrides '.trigger' to avoid attaching listeners to reference.
     trigger: undefined
   });

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -309,4 +309,28 @@ describe('menu', () => {
 
   });
 
+  it('should support opening a popup', async function() {
+
+    // open the first menu
+    await driver.find('.test-btn1').click();
+
+    // check that menu is open and popup is not
+    await assertOpen('.test-popup', false);
+    await assertOpen('.test-menu1', true);
+
+    // trigger the opening of the popup
+    await driver.find('.test-popup-open').click();
+
+    // check that menu is now closed and popup is opened
+    await assertOpen('.test-popup', true);
+    await assertOpen('.test-menu1', false);
+
+    // close the popup
+    await driver.find('.test-popup-close').click();
+
+    // check that both the menu and the popup are closed
+    await assertOpen('.test-popup', false);
+    await assertOpen('.test-menu1', false);
+  });
+
 });

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -3,7 +3,7 @@
  */
 // tslint:disable:no-console
 import {dom, DomElementArg, input, makeTestId, obsArray, observable, styled, TestId} from 'grainjs';
-import {cssMenuDivider, menu, menuItem, menuItemLink, menuItemSubmenu} from '../../index';
+import {cssMenuDivider, menu, menuItem, menuItemLink, menuItemSubmenu, popupOpen} from '../../index';
 import {IOpenController, PopupControl} from '../../index';
 import {autocomplete, inputMenu, select} from '../../index';
 
@@ -114,6 +114,10 @@ function makeMenu(ctl: IOpenController): DomElementArg[] {
       lastAction.set("Show/Hide Cut");
     }, dom.text((use) => use(hideCut) ? "Show Cut" : "Hide Cut")),
     menuItem(() => resetBtn.focus(), 'Focus Reset', testId('focus-reset')),
+    menuItem((elem) => popupOpen(elem, buildPopupContent, {
+      placement: 'right',
+    }), "popup", testId('popup-open')
+    ),
     cssMenuDivider(),
     menuItemSubmenu(makePasteSubmenu, {}, "Paste Special", testId('sub-item')),
   ];
@@ -218,6 +222,17 @@ function makeComplexAutocomplete(): HTMLInputElement {
   });
 }
 
+function buildPopupContent(ctl: IOpenController): HTMLElement {
+  return cssPopupContent(
+    "Hello World",
+    cssButton(
+      'Ok', dom.on('click', () => ctl.close()),
+      testId('popup-close')
+    ),
+    testId('popup')
+  );
+}
+
 const cssExample = styled('div', `
   position: relative;
   overflow: auto;
@@ -228,7 +243,6 @@ const cssExample = styled('div', `
   font-size: 100%;
   font-family: sans-serif;
   vertical-align: baseline;
-  height: 400px;
   width: 500px;
   padding: 16px;
 
@@ -312,6 +326,10 @@ const cssInputMenu = styled('div', `
 const funkyOptions = {
   menuCssClass: cssFunkyMenu.className,
 };
+
+const cssPopupContent = styled('div', `
+  background-color: darkCyan;
+`);
 
 document.addEventListener('DOMContentLoaded', () => {
   document.body.appendChild(setupTest());

--- a/test/init-mocha-webdriver.js
+++ b/test/init-mocha-webdriver.js
@@ -1,0 +1,15 @@
+/**
+ * Settings that affect tests using mocha-webdriver. This module is imported by any run of mocha, by
+ * being listed in test/mocha.opts.
+ */
+"use strict";
+
+// Enable enhanced stacktraces by default. Disable by running with MOCHA_WEBDRIVER_STACKTRACES="".
+if (process.env.MOCHA_WEBDRIVER_STACKTRACES === undefined) {
+  process.env.MOCHA_WEBDRIVER_STACKTRACES = "1";
+}
+
+// Don't fail on mismatched Chrome versions. Disable with MOCHA_WEBDRIVER_IGNORE_CHROME_VERSION="".
+if (process.env.MOCHA_WEBDRIVER_IGNORE_CHROME_VERSION === undefined) {
+  process.env.MOCHA_WEBDRIVER_IGNORE_CHROME_VERSION = "1";
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --require ts-node/register
+test/init-mocha-webdriver


### PR DESCRIPTION
This adds the `popupOpen` interface which allows to easily create a popup using `() => popupOpen(refElement, (ctl) => buildDom(ctl), {placement: ...}). This will be useful in Grist to bind the creation of the page widget picker to a menu item.
To make it possible this commit also exposes the `.update` methods to the IOpenController interface - needed by the page widget picker creator - and also passes the trigger element to the action callbacks triggered by menu items.