### PR TITLE
Makes autocomplete update the trigger's value on tab

### DIFF
--- a/lib/autocomplete.ts
+++ b/lib/autocomplete.ts
@@ -98,9 +98,9 @@ class Autocomplete extends BaseMenu implements IPopupContent {
         this._updateValue(trigger);
       },
       // On Enter (and Tab) key, we update the trigger's value and close the dropdown. We always let
-      // event propagate (notice the '$' at the end of 'Enter$') because it is often desirable to
-      // listen to eigher one of Enter (or Tab) key on an input element. Note that the menu items'
-      // action does not run on Enter because the focus remains on the trigger element at all time.
+      // event propagate (notice the '$' at the end of 'Enter$') because the user may want to handle
+      // these events independently as well. Note that the menu items' action does not run on Enter
+      // because the focus remains on the trigger element at all time.
       Enter$: (ev) => {
         this._updateValue(trigger);
         ctl.close();
@@ -108,7 +108,8 @@ class Autocomplete extends BaseMenu implements IPopupContent {
       Tab$: (ev) => {
         this._updateValue(trigger);
         ctl.close();
-      }
+      },
+      Escape$: () => ctl.close(),
     }));
 
     this.autoDispose(onElem(trigger, 'input', () => {

--- a/lib/autocomplete.ts
+++ b/lib/autocomplete.ts
@@ -97,16 +97,18 @@ class Autocomplete extends BaseMenu implements IPopupContent {
         this.prevIndex();
         this._updateValue(trigger);
       },
-      // On Enter key, if an item is selected we update the value and close the dropdown. We always
-      // let event propagate (notice the '$' at the end of 'Enter$') because it is often desirable
-      // to listen to the enter key on an input element. Note that the items' action do not run on
-      // Enter because the focus remain on the trigger element.
+      // On Enter (and Tab) key, we update the trigger's value and close the dropdown. We always let
+      // event propagate (notice the '$' at the end of 'Enter$') because it is often desirable to
+      // listen to eigher one of Enter (or Tab) key on an input element. Note that the menu items'
+      // action does not run on Enter because the focus remains on the trigger element at all time.
       Enter$: (ev) => {
-        if (this._selected) {
-          trigger.value = this._selected.textContent!;
-          ctl.close();
-        }
+        this._updateValue(trigger);
+        ctl.close();
       },
+      Tab$: (ev) => {
+        this._updateValue(trigger);
+        ctl.close();
+      }
     }));
 
     this.autoDispose(onElem(trigger, 'input', () => {


### PR DESCRIPTION
This diff makes hitting the tab key behaves the same as hitting the enter key, namely: udpates the trigger's value to the selected one and close the dropdown. This satisfies a request from Grist, for the choice Editor. But it also seems reasonable enough to make it the default. Note: Jquery autocomplete also seems to have same behavior for tab en enter (when an item is selected).