### PR TITLE
Adds attach options to ISelectUserOptions

### DIFF
--- a/lib/select.ts
+++ b/lib/select.ts
@@ -1,7 +1,7 @@
 import {dom, DomArg, DomElementArg, onElem, styled} from 'grainjs';
 import {BindableValue, Computed, MaybeObsArray, Observable} from 'grainjs';
 import {BaseMenu, defaultMenuOptions, IMenuOptions, menuItem} from './menu';
-import {IOpenController, PopupControl, setPopupToFunc} from './popup';
+import {IOpenController, IPopupOptions, PopupControl, setPopupToFunc} from './popup';
 
 export interface IOptionFull<T> {
   value: T;
@@ -22,6 +22,7 @@ export interface ISelectUserOptions {
   buttonCssClass?: string  // If provided, applies the css class to the select button.
   // If disabled, adds the .disabled class to the select button and prevents opening.
   disabled?: BindableValue<boolean>;
+  attach?: IPopupOptions['attach'];
 }
 
 export interface ISelectOptions extends IMenuOptions {
@@ -86,6 +87,7 @@ export function select<T>(
   const selectOptions: ISelectOptions = {
     ...defaultMenuOptions,
     menuCssClass: options.menuCssClass,
+    attach: options.attach === undefined ? defaultMenuOptions.attach : options.attach,
     trigger: [(triggerElem: Element, ctl: PopupControl) => {
       dom.onElem(triggerElem, 'click', () => isDisabled() || ctl.toggle()),
       dom.onKeyElem(triggerElem as HTMLElement, 'keydown', {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "url": "https://github.com/gristlabs/weasel.js/issues"
   },
   "homepage": "https://github.com/gristlabs/weasel.js#readme",
+  "peerDependencies": {
+    "grainjs": "^1.0.1"
+  },
   "dependencies": {
-    "grainjs": "^1.0.1",
     "lodash": "^4.17.15",
     "popper.js": "1.15.0"
   },
@@ -41,6 +43,7 @@
     "@types/webpack-dev-server": "^3.1.5",
     "cache-loader": "^3.0.0",
     "fork-ts-checker-webpack-plugin": "^1.2.0",
+    "grainjs": "^1.0.1",
     "mocha": "6.1.4",
     "mocha-webdriver": "^0.2.0",
     "ts-loader": "^5.4.4",


### PR DESCRIPTION
 - The .attach options is what makes it possible to nest the select in
   a popup without having the popup to close when clicking on the
   nested dropdown.

 - Also makes grainjs a peerDependencies which makes it easier to
   consume local repository with `yarn link`. To do so you have to
   install packages with production mode ON, ie: `yarn install --prod`
   and then use `yarn link`. Making grainjs a peerDependencies removes
   compatiblity issues between versions of grainjs with host
   repository.