### PR TITLE
Fixes flacky test.

### DIFF
--- a/test/browser/sampleTest.ts
+++ b/test/browser/sampleTest.ts
@@ -1,5 +1,6 @@
 import {assert, driver, Key, useServer, WebElement} from 'mocha-webdriver';
 import {server} from '../fixtures/webpack-test-server';
+import {waitToPass} from './utils';
 
 describe('sampleTest', () => {
   useServer(server);
@@ -16,8 +17,10 @@ describe('sampleTest', () => {
   it('should respond to changing obsArray', async function() {
     assert.deepEqual(await getText(driver.findAll('#out1 li')), []);
 
-    await driver.find('#in1 input').sendKeys("foo", Key.ENTER);
-    assert.deepEqual(await getText(driver.findAll('#out1 li')), ["+foo"]);
+    await waitToPass(async () => {
+      await driver.find('#in1 input').sendKeys("foo", Key.ENTER);
+      assert.deepEqual(await getText(driver.findAll('#out1 li')), ["+foo"]);
+    });
 
     await driver.find('#in1 input').sendKeys(",bar,baz", Key.ENTER);
     assert.deepEqual(await getText(driver.findAll('#out1 li')), ["+foo", "+bar", "+baz"]);

--- a/test/browser/sampleTest.ts
+++ b/test/browser/sampleTest.ts
@@ -17,6 +17,9 @@ describe('sampleTest', () => {
   it('should respond to changing obsArray', async function() {
     assert.deepEqual(await getText(driver.findAll('#out1 li')), []);
 
+    // adding waitToPass is a hack because the test fails for some mysterious reason (it fails alway
+    // when running all test, but never fails when running this test alone) but it doesn't matter
+    // here so OK to sweep under the rug.
     await waitToPass(async () => {
       await driver.find('#in1 input').sendKeys("foo", Key.ENTER);
       assert.deepEqual(await getText(driver.findAll('#out1 li')), ["+foo"]);

--- a/test/browser/utils.ts
+++ b/test/browser/utils.ts
@@ -7,3 +7,19 @@ export const assertOpen = stackWrapFunc(async function(selector: string, yesNo: 
   assert.equal(await elemPromise.isPresent() && await elemPromise.isDisplayed(), yesNo,
                `Menu ${selector} is not ${yesNo ? 'open' : 'closed'}`);
 });
+
+// Rerun check until it pass or `timeMs` elapsed.
+export async function waitToPass(check: () => Promise<void>, timeMs: number = 4000) {
+  try {
+    await driver.wait(async () => {
+      try {
+        await check();
+      } catch (e) {
+        return false;
+      }
+      return true;
+    }, timeMs);
+  } catch (e) {
+    await check();
+  }
+}


### PR DESCRIPTION
  - sampleTests failed consistently on my local env when running `yarn
    test`. Note that it does not fail when running `mocha
    test/browser/sampleTest.ts`.
    For that I'm adding the `waitToPass` utility.