### PR TITLE
Allow to add arbitrary DOM args to menus

### DIFF
--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -21,6 +21,7 @@ import {IOpenController, IPopupContent, IPopupOptions, PopupControl, setPopupToF
 import {ISelectOptions} from './select';
 
 export type MenuCreateFunc = (ctl: IOpenController) => DomElementArg[];
+export type MenuDomArgs  = DomElementArg[] | ((ctl: IOpenController) => DomElementArg[]);
 
 type MenuClassCons = (context: any, ctl: IOpenController, items: DomElementArg[], options?: IMenuOptions) => BaseMenu;
 
@@ -48,6 +49,12 @@ export interface IMenuOptions extends IPopupOptions {
   // down on the last item selects the first one, and pressing the arrow up on the first item
   // selects the last one.
   allowNothingSelected?: boolean;
+
+  // You can pass additional DOM args to the menu container, optionally passing them through a function
+  // that receives the menu controller as an argument if needed.
+  //    menuDomArgs: [ {"data-random-attribute": "random value"} ]
+  //    menuDomArgs: (ctl) => [ (menuEl) => { attachRandomThingToCtl(menuEl, ctl) } ]
+  menuDomArgs?: MenuDomArgs;
 }
 
 export interface ISubMenuOptions {
@@ -173,6 +180,9 @@ export class BaseMenu extends Disposable implements IPopupContent {
 
     this._allowNothingSelected = Boolean(options.allowNothingSelected);
 
+    const menuDomArgs = typeof options.menuDomArgs === 'function' ?
+      options.menuDomArgs(ctl) : (options.menuDomArgs || []);
+
     this.content = cssMenuWrap({class: options.menuWrapCssClass || ''},
       this._menuContent = cssMenu({class: options.menuCssClass || ''},
         items,
@@ -186,6 +196,7 @@ export class BaseMenu extends Disposable implements IPopupContent {
             ArrowLeft: () => ctl.close(0),
           } : {},
         }),
+        ...menuDomArgs,
       ),
       // Events set on the parent of _menuContent receive events bubbled up from submenus.
       dom.on('click', (ev) => isInSelectableItem(ev.target as Element) ? ctl.close(0) : ev.stopPropagation()),

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -21,7 +21,6 @@ import {IOpenController, IPopupContent, IPopupOptions, PopupControl, setPopupToF
 import {ISelectOptions} from './select';
 
 export type MenuCreateFunc = (ctl: IOpenController) => DomElementArg[];
-export type MenuDomArgs  = DomElementArg[] | ((ctl: IOpenController) => DomElementArg[]);
 
 type MenuClassCons = (context: any, ctl: IOpenController, items: DomElementArg[], options?: IMenuOptions) => BaseMenu;
 
@@ -50,11 +49,12 @@ export interface IMenuOptions extends IPopupOptions {
   // selects the last one.
   allowNothingSelected?: boolean;
 
-  // You can pass additional DOM args to the menu container, optionally passing them through a function
-  // that receives the menu controller as an argument if needed.
-  //    menuDomArgs: [ {"data-random-attribute": "random value"} ]
-  //    menuDomArgs: (ctl) => [ (menuEl) => { attachRandomThingToCtl(menuEl, ctl) } ]
-  menuDomArgs?: MenuDomArgs;
+  // For specific use cases, you can modify the menu `ul` element the usual grainjs way,
+  // and/or act on the tied weasel controller.
+  //    modifyContent: (menuEl, ctl) => ({ "data-random-attribute": "random value" })
+  //    modifyContent: (menuEl, ctl) => attachRandomThingToCtl(ctl)
+  //    modifyContent: (menuEl, ctl) => [attachRandomThingToCtl(ctl), {"data-random": "value"}]
+  modifyContent?: (menuEl: HTMLElement, ctl: IOpenController) => DomElementArg;
 }
 
 export interface ISubMenuOptions {
@@ -180,9 +180,6 @@ export class BaseMenu extends Disposable implements IPopupContent {
 
     this._allowNothingSelected = Boolean(options.allowNothingSelected);
 
-    const menuDomArgs = typeof options.menuDomArgs === 'function' ?
-      options.menuDomArgs(ctl) : (options.menuDomArgs || []);
-
     this.content = cssMenuWrap({class: options.menuWrapCssClass || ''},
       this._menuContent = cssMenu({class: options.menuCssClass || ''},
         items,
@@ -196,7 +193,7 @@ export class BaseMenu extends Disposable implements IPopupContent {
             ArrowLeft: () => ctl.close(0),
           } : {},
         }),
-        ...menuDomArgs,
+        (el) => options.modifyContent?.(el, ctl)
       ),
       // Events set on the parent of _menuContent receive events bubbled up from submenus.
       dom.on('click', (ev) => isInSelectableItem(ev.target as Element) ? ctl.close(0) : ev.stopPropagation()),

--- a/lib/select.ts
+++ b/lib/select.ts
@@ -1,6 +1,6 @@
 import {dom, DomArg, DomContents, DomElementArg, onElem, styled} from 'grainjs';
 import {BindableValue, Computed, MaybeObsArray, Observable} from 'grainjs';
-import {BaseMenu, defaultMenuOptions, IMenuOptions, menuItem} from './menu';
+import {BaseMenu, defaultMenuOptions, IMenuOptions, menuItem, MenuDomArgs} from './menu';
 import {IOpenController, IPopupOptions, PopupControl, setPopupToFunc} from './popup';
 
 export interface IOptionFull<T> {
@@ -19,6 +19,7 @@ export interface ISelectUserOptions {
   defaultLabel?: string;   // Button label displayed when no value is selected.
   buttonArrow?: DomArg;    // DOM for what is typically the chevron on the select button.
   menuCssClass?: string;   // If provided, applies the css class to the menu container.
+  menuDomArgs?: MenuDomArgs;  // Optional DOM args applied to the menu container.
   menuWrapCssClass?: string;  // See menu.ts.
   buttonCssClass?: string;  // If provided, applies the css class to the select button.
   // If disabled, adds the .disabled class to the select button and prevents opening.
@@ -88,6 +89,7 @@ export function select<T>(
   const selectOptions: ISelectOptions = {
     ...defaultMenuOptions,
     menuCssClass: options.menuCssClass,
+    menuDomArgs: options.menuDomArgs,
     menuWrapCssClass: options.menuWrapCssClass,
     attach: options.attach === undefined ? defaultMenuOptions.attach : options.attach,
     trigger: [(triggerElem: Element, ctl: PopupControl) => {

--- a/lib/select.ts
+++ b/lib/select.ts
@@ -1,6 +1,6 @@
 import {dom, DomArg, DomContents, DomElementArg, onElem, styled} from 'grainjs';
 import {BindableValue, Computed, MaybeObsArray, Observable} from 'grainjs';
-import {BaseMenu, defaultMenuOptions, IMenuOptions, menuItem, MenuDomArgs} from './menu';
+import {BaseMenu, defaultMenuOptions, IMenuOptions, menuItem} from './menu';
 import {IOpenController, IPopupOptions, PopupControl, setPopupToFunc} from './popup';
 
 export interface IOptionFull<T> {
@@ -19,8 +19,8 @@ export interface ISelectUserOptions {
   defaultLabel?: string;   // Button label displayed when no value is selected.
   buttonArrow?: DomArg;    // DOM for what is typically the chevron on the select button.
   menuCssClass?: string;   // If provided, applies the css class to the menu container.
-  menuDomArgs?: MenuDomArgs;  // Optional DOM args applied to the menu container.
   menuWrapCssClass?: string;  // See menu.ts.
+  modifyContent?: IMenuOptions['modifyContent'];
   buttonCssClass?: string;  // If provided, applies the css class to the select button.
   // If disabled, adds the .disabled class to the select button and prevents opening.
   disabled?: BindableValue<boolean>;
@@ -89,7 +89,7 @@ export function select<T>(
   const selectOptions: ISelectOptions = {
     ...defaultMenuOptions,
     menuCssClass: options.menuCssClass,
-    menuDomArgs: options.menuDomArgs,
+    modifyContent: options.modifyContent,
     menuWrapCssClass: options.menuWrapCssClass,
     attach: options.attach === undefined ? defaultMenuOptions.attach : options.attach,
     trigger: [(triggerElem: Element, ctl: PopupControl) => {

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -323,6 +323,17 @@ describe('menu', () => {
 
   });
 
+  it('should support the modifyContent argument to customize the dropdown element', async function() {
+    await driver.find('.test-btn-modify-content').click();
+    await assertOpen('.test-modify-content-menu', true);
+
+    const menuEl = await driver.find('.test-modify-content-menu');
+    assert.include(await menuEl.getAttribute('class'), 'modify-content-open-class');
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-modify-content-menu', false);
+  });
+
   it('should support opening a popup', async function() {
 
     // open the first menu

--- a/test/browser/select.ts
+++ b/test/browser/select.ts
@@ -98,4 +98,10 @@ describe('select', () => {
     assert.isTrue(await driver.findContent('li', /apricot/).matches('[class*=-sel]'));
     await driver.sendKeys(Key.ESCAPE);
   });
+
+  it('should support the modifyContent argument to customize the dropdown element', async function() {
+    await driver.find('.test-btn3').click();
+    assert.equal(await driver.findWait('.test-select-dropdown', 100).getAttribute('data-modify-content-attr'), 'select');
+    await driver.sendKeys(Key.ESCAPE);
+  });
 });

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -58,6 +58,17 @@ function setupTest() {
       testId('btn5'),
       menu(makeMenu, {allowNothingSelected: true}),
     ),
+    cssButton('My Menu with modifyContent arg',
+      testId('btn-modify-content'),
+      menu(() => [
+        testId('modify-content-menu'),
+        menuItem(() => console.log('Menu item: ModifyContent'), 'ModifyContent', testId('modify-content-item')),
+      ], {
+        modifyContent: (menuEl, ctl) => {
+          ctl.setOpenClass(menuEl, 'modify-content-open-class');
+        },
+      }),
+    ),
     makeSelect(),
     makeComplexSelect(),
     cssInputContainer(
@@ -182,7 +193,11 @@ function makeSelect() {
   const btnElem = dom('div', testId('btn3'));
   const menuCssClass = dom('div', testId('select-dropdown')).className;
   return dom('div', { style: `width: 200px;` },
-    select(fruit, fruits, { buttonCssClass: btnElem.className, menuCssClass })
+    select(fruit, fruits, {
+      buttonCssClass: btnElem.className,
+      menuCssClass,
+      modifyContent: () => ({'data-modify-content-attr': 'select'})
+    })
   );
 }
 


### PR DESCRIPTION
Hey there @dsagal :wave: 

When trying to improve keyboard management on selects in grist, I had trouble tinkering with popweasel's selects the same way I can already do with simpler menus. Through the `createFunc` of menu we can, somewhat not that obviously, add any dom args we want and be done with it. But for selects, this seems not possible.

This PR adds a new option that can be used as some kind of escape-hatch to deal with specific use cases where you would want to modify some internal behavior.

Didn't spend much time on it yet (like, I didn't add any test), as I'm curious if that would be okay with you first.

In Grist, I want to add some logic on basically every dropdown menu, kinda like how `registerMenuOpen` already exists, but I also want to apply the logic to selects (from my understand, this "registerMenuOpen" isn't applied on selects).

Thoughts? Thanks!