### PR TITLE
Simple menus and selects: better semantics thanks to ARIA attributes

### DIFF
--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -13,7 +13,7 @@
  * Clicks on items will normally propagate to the menu, where they get caught and close the menu.
  * If a click on an item should not close the menu, the item should stop the click's propagation.
  */
-import {dom, domDispose, DomElementArg, DomElementMethod, DomMethod, EventCB, styled} from 'grainjs';
+import {dom, domDispose, DomElementArg, DomElementMethod, DomMethod, EventCB, IDomArgs, styled} from 'grainjs';
 import {Disposable, onKeyDown, onKeyElem} from 'grainjs';
 import defaultsDeep = require('lodash/defaultsDeep');
 import mergeWith = require('lodash/mergeWith');
@@ -507,12 +507,17 @@ export const cssMenuItemLink = styled('a', `
   }
 `);
 
-export const cssMenuDivider = styled('div', `
+const _cssMenuDivider = styled('div', `
   height: 1px;
   width: 100%;
   margin: 4px 0;
   background-color: #D9D9D9;
 `);
+
+export const cssMenuDivider = Object.assign(
+  (...args: IDomArgs<HTMLDivElement>) => _cssMenuDivider({ 'aria-hidden': 'true' }, ...args ),
+  _cssMenuDivider,
+);
 
 export const cssExpandIcon = styled('div.weasel-popup-expand-icon', `
   flex: none;

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -75,6 +75,16 @@ export function menu(createFunc: MenuCreateFunc, options?: IMenuOptions): DomEle
   return (elem) => menuElem(elem, createFunc, options);
 }
 export function menuElem(triggerElem: Element, createFunc: MenuCreateFunc, options: IMenuOptions = {}) {
+  // try to automatically fix potentially bad uses of trigger elements: make sure they are exposed as buttons
+  // to assistive technologies, and reachable with the keyboard.
+  if (triggerElem.tagName !== 'BUTTON') {
+    if (!triggerElem.getAttribute('role')) {
+      triggerElem.setAttribute('role', 'button');
+    }
+    if (!triggerElem.getAttribute('tabindex')) {
+      triggerElem.setAttribute('tabindex', '0');
+    }
+  }
   return baseElem((...args) => Menu.create(...args), triggerElem, createFunc, options);
 }
 
@@ -138,7 +148,7 @@ export const defaultMenuOptions: IMenuOptions = {
   boundaries: 'viewport',
   placement: 'bottom-start',
   showDelay: 0,
-  trigger: ['click'],
+  trigger: ['click', {keys: ['Enter']}],
   modifiers: {
     // gpuAcceleration (true by default) causes a tiny UI artifact: attempting to drag a link, at
     // least in Firefox, causes it to be dragged from a different location on the screen where it

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -4,7 +4,11 @@
  *
  * The standard menu item offers enough flexibility to suffice for many needs, and may be replaced
  * entirely by a custom item. For an item to be a selectable menu item, it needs `tabindex=-1`
- * attribute set. If unset, or if the "disabled" class is set, the item will not be selectable.
+ * attribute set. If unset, or if "aria-disabled" is set to "true", or if the "disabled" class is set[*],
+ * the item will not be selectable.
+ *
+ * [*] Note that using "aria-disabled" is preferred over the "disabled" class for better compatibility
+ * with assistive technologies.
  *
  * Further, if `dom.dataElem(elem, 'menuItemSelected', (yesNo: boolean, elem) => {})` is set, that
  * callback will be called whenever the item is selected and unselected. In addition, the selected
@@ -127,8 +131,8 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
 /**
  * Implements a single menu item.
  *
- * The item is generated with tabindex="-1". To generate a menu item that is not selectable, add the "disabled" class
- * to the additional args.
+ * The item is generated with tabindex="-1". To generate a menu item that is not selectable,
+ * set its "aria-disabled" attribute to "true" with additional args.
  *
  * The appearance of the menuItem components can be changed by setting the followingcss variables
  * in the parent project:
@@ -141,7 +145,7 @@ export function menuItem(action: (item: HTMLElement, ev: Event) => void, ...args
     ...args,
     dom.on('click', (ev, elem) => {
       const item = findMenuItem(elem);
-      if (item?.classList.contains('disabled')) {
+      if (item?.classList.contains('disabled') || item?.getAttribute('aria-disabled') === 'true') {
         return;
       }
       const isCheckbox = item?.getAttribute('role') === 'menuitemcheckbox'
@@ -444,7 +448,8 @@ function isMenuContainer(elem: Element|null) {
  */
 function isSelectable(elem: Element): elem is HTMLElement {
   // Offset height > 0 is used to determine if the element is visible.
-  return elem.hasAttribute('tabIndex') && !elem.classList.contains('disabled') &&
+  return elem.hasAttribute('tabIndex') &&
+    !(elem.classList.contains('disabled') || elem.getAttribute('aria-disabled') === 'true') &&
     (elem as HTMLElement).offsetHeight > 0;
 }
 
@@ -540,7 +545,9 @@ export function menuItemSubmenu(
 
     // Clicks that open a submenu should not cause parent menu to close.
     dom.on('click', (ev, elem) => {
-      if (options.action && !elem.classList.contains('disabled')) {
+      if (options.action &&
+        !(elem.classList.contains('disabled') || elem.getAttribute('aria-disabled') === 'true')
+      ) {
         options.action(elem, ev);
       } else {
         ev.stopPropagation();
@@ -586,7 +593,7 @@ export const cssMenuItem = styled('li', `
     background-color: var(--weaseljs-selected-background-color, #5AC09C);
     color:            var(--weaseljs-selected-color, white);
   }
-  &.disabled {
+  &.disabled, &[aria-disabled="true"] {
     color: grey;
   }
 `);

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -495,9 +495,11 @@ function isMenuContainer(elem: Element|null) {
  */
 function isSelectable(elem: Element): elem is HTMLElement {
   // Offset height > 0 is used to determine if the element is visible.
-  return elem.hasAttribute('tabIndex') &&
-    !(elem.classList.contains('disabled') || elem.getAttribute('aria-disabled') === 'true') &&
-    (elem as HTMLElement).offsetHeight > 0;
+  return elem.hasAttribute('tabIndex') && !isDisabled(elem) && (elem as HTMLElement).offsetHeight > 0;
+}
+
+function isDisabled(elem: Element): boolean {
+  return elem?.classList.contains('disabled') || elem?.getAttribute('aria-disabled') === 'true';
 }
 
 /**
@@ -586,9 +588,7 @@ export function menuItemSubmenu(
 
     // Clicks that open a submenu should not cause parent menu to close.
     dom.on('click', (ev, elem) => {
-      if (options.action &&
-        !(elem.classList.contains('disabled') || elem.getAttribute('aria-disabled') === 'true')
-      ) {
+      if (options.action && !isDisabled(elem)) {
         options.action(elem, ev);
       } else {
         ev.stopPropagation();

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -127,6 +127,9 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
 /**
  * Implements a single menu item.
  *
+ * The item is generated with tabindex="-1". To generate a menu item that is not selectable, add the "disabled" class
+ * to the additional args.
+ *
  * The appearance of the menuItem components can be changed by setting the followingcss variables
  * in the parent project:
  *    --weaseljs-selected-background-color
@@ -136,8 +139,35 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
 export function menuItem(action: (item: HTMLElement, ev: Event) => void, ...args: DomElementArg[]): Element {
   return cssMenuItem(
     ...args,
-    dom.on('click', (ev, elem) => elem.classList.contains('disabled') || action(elem, ev)),
-    onKeyDown({Enter$: (ev, elem) => action(elem, ev)})
+    dom.on('click', (ev, elem) => {
+      const item = findMenuItem(elem);
+      if (item?.classList.contains('disabled')) {
+        return;
+      }
+      const isCheckbox = item?.getAttribute('role') === 'menuitemcheckbox'
+        && (ev.target as HTMLElement).tagName.toLowerCase() === 'input'
+        && (ev.target as HTMLInputElement).type === 'checkbox';
+      // If we click a checkbox inside a menuitemcheckbox, we assume we want the checkbox to be visually toggled, so
+      // we let default behavior occur. Without this exception, clicking the checkbox itself would not update its UI.
+      // Otherwise, make sure to prevent default element action to avoid issues (e.g. clicking a label triggers
+      // a click on the tied input, and we don't want that).
+      if (!isCheckbox) {
+        ev.preventDefault();
+      }
+      action(elem, ev);
+    }),
+    // `tabindex="-1"` is automatically added by the onKeyDown helper, making the item selectable by default.
+    onKeyDown({
+      "Enter$": (ev, elem) => {
+        action(elem, ev)
+      },
+      // Space key is used to toggle a checkbox item without closing the parent menu.
+      " $": (ev, elem) => {
+        if (elem.getAttribute('role') === 'menuitemcheckbox') {
+          action(elem, ev);
+        }
+      }
+    })
   );
 }
 
@@ -247,7 +277,16 @@ export class BaseMenu extends Disposable implements IPopupContent {
         (el) => options.modifyContent?.(el, ctl)
       ),
       // Events set on the parent of _menuContent receive events bubbled up from submenus.
-      dom.on('click', (ev) => isInSelectableItem(ev.target as Element) ? ctl.close(0) : ev.stopPropagation()),
+      dom.on('click', (ev) => {
+        if (isInSelectableItem(ev.target as Element)) {
+          // Items might be checkboxes, in that case we don't want to close the menu on click
+          if (findMenuItem(ev.target as Element)?.getAttribute('role') !== 'menuitemcheckbox') {
+            ctl.close(0);
+          }
+        } else {
+          ev.stopPropagation();
+        }
+      }),
       options.isSubMenu ? null :
         onKeyDown({
           Escape: () => ctl.close(0),
@@ -359,7 +398,10 @@ export class Menu extends BaseMenu implements IPopupContent {
   constructor(ctl: IOpenController, items: DomElementArg[], options: IMenuOptions = {}) {
     super(ctl, items, options);
     for (const child of this._menuContent.children) {
-      child.setAttribute('role', 'menuitem');
+      const existingRole = child.getAttribute('role');
+      if (!existingRole || !['menuitem', 'menuitemcheckbox'].includes(existingRole)) {
+        child.setAttribute('role', 'menuitem');
+      }
     }
     updateListAria(this, ctl.getTriggerElem(), this._menuContent, {role: 'menu'});
 
@@ -400,13 +442,17 @@ function isSelectable(elem: Element): elem is HTMLElement {
     (elem as HTMLElement).offsetHeight > 0;
 }
 
+function findMenuItem(elem: Element) {
+  return findAncestorChild(elem.closest('.' + cssMenu.className)!, elem);
+}
+
 /**
  * Whether the given element is part of a selectable item. A click on it will close menus.
  */
 function isInSelectableItem(elem: Element): boolean {
   // Similar to _findTargetItem, but finds the menu item (direct child of cssMenu) containing
   // elem, regardless of which menu or submenu it's in, and returns whether it's selectable.
-  const item = findAncestorChild(elem.closest('.' + cssMenu.className)!, elem);
+  const item = findMenuItem(elem);
   return item ? isSelectable(item) : false;
 }
 

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -548,7 +548,7 @@ export function menuItemSubmenu(
     options.expandIcon ? options.expandIcon() : cssExpandIcon(),
     dom.autoDispose(ctl),
 
-    {role: 'menuitem'},
+    {'role': 'menuitem', 'aria-expanded': 'false'},
 
     // Set the submenu to be attached as a child of this element rather than as a sibling.
     menu(submenu, popupOptions),

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -13,7 +13,7 @@
  * Clicks on items will normally propagate to the menu, where they get caught and close the menu.
  * If a click on an item should not close the menu, the item should stop the click's propagation.
  */
-import {dom, domDispose, DomElementArg, DomElementMethod, DomMethod, EventCB, IDomArgs, styled} from 'grainjs';
+import {dom, domDispose, DomElementArg, DomElementMethod, DomMethod, EventCB, styled} from 'grainjs';
 import {Disposable, onKeyDown, onKeyElem} from 'grainjs';
 import defaultsDeep = require('lodash/defaultsDeep');
 import mergeWith = require('lodash/mergeWith');
@@ -183,6 +183,9 @@ export function updateListAria(
   triggerElem.setAttribute('aria-expanded', 'true');
   triggerElem.setAttribute('aria-controls', listId);
   triggerElem.setAttribute('aria-owns', listId);
+  if (options.role === 'menu' && triggerElem.id) {
+    listElem.setAttribute('aria-labelledby', triggerElem.id);
+  }
   menu.onDispose(() => {
     triggerElem.setAttribute('aria-expanded', 'false');
     triggerElem.removeAttribute('aria-controls');
@@ -346,10 +349,9 @@ export class BaseMenu extends Disposable implements IPopupContent {
 export class Menu extends BaseMenu implements IPopupContent {
   constructor(ctl: IOpenController, items: DomElementArg[], options: IMenuOptions = {}) {
     super(ctl, items, options);
-    Array.from(this._menuContent.children).forEach(child => {
+    for (const child of this._menuContent.children) {
       child.setAttribute('role', 'menuitem');
-    });
-    this._menuContent.setAttribute('aria-labelledby', ctl.getTriggerElem().id);
+    }
     updateListAria(this, ctl.getTriggerElem(), this._menuContent, {role: 'menu'});
 
     setTimeout(() =>
@@ -546,17 +548,12 @@ export const cssMenuItemLink = styled('a', `
   }
 `);
 
-const _cssMenuDivider = styled('div', `
+export const cssMenuDivider = styled((...args: DomElementArg[]) => dom("div", { "aria-hidden": "true" }, ...args), `
   height: 1px;
   width: 100%;
   margin: 4px 0;
   background-color: #D9D9D9;
 `);
-
-export const cssMenuDivider = Object.assign(
-  (...args: IDomArgs<HTMLDivElement>) => _cssMenuDivider({ 'aria-hidden': 'true' }, ...args ),
-  _cssMenuDivider,
-);
 
 export const cssExpandIcon = styled('div.weasel-popup-expand-icon', `
   flex: none;

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -252,6 +252,11 @@ export class BaseMenu extends Disposable implements IPopupContent {
         onKeyDown({
           Escape: () => ctl.close(0),
           Enter: () => ctl.close(0),    // gets bubbled key after action is taken.
+          // prevent using the Tab key to navigate: we use arrow keys
+          Tab: (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+          },
         }),
     );
     this.onDispose(() => domDispose(this.content));

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -220,7 +220,7 @@ export function updateListAria(
   }
   triggerElem.setAttribute('aria-controls', listId);
   triggerElem.setAttribute('aria-owns', listId);
-  if (options.role === 'menu' && triggerElem.id) {
+  if (options.role === 'menu' && triggerElem.id && !listElem.getAttribute('aria-labelledby')) {
     listElem.setAttribute('aria-labelledby', triggerElem.id);
   }
   menu.onDispose(() => {

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -263,6 +263,8 @@ export function updateListAria(
     triggerElem.setAttribute('aria-expanded', 'true');
   }
   triggerElem.setAttribute('aria-controls', listElem.id);
+  // Without aria-owns, some screen readers announce unnecessary and verbose context change when closing the menu,
+  // because the menu's list is a direct child of the body element and not a child or sibling of the trigger element.
   triggerElem.setAttribute('aria-owns', listElem.id);
   if (options.role === 'menu' && triggerElem.id && !listElem.getAttribute('aria-labelledby')) {
     listElem.setAttribute('aria-labelledby', triggerElem.id);

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -4,11 +4,15 @@
  *
  * The standard menu item offers enough flexibility to suffice for many needs, and may be replaced
  * entirely by a custom item. For an item to be a selectable menu item, it needs `tabindex=-1`
- * attribute set, and a role of either "menuitem", "menuitemcheckbox", or "option" (for selects).
- * If there is no tabindex or role, if "aria-disabled" is set to "true", or if the "disabled" class is set[*],
+ * attribute set, and a role of either "menuitem", "menuitemcheckbox"[1], or "option" (for selects).
+ * If there is no tabindex or role, if "aria-disabled" is set to "true", or if the "disabled" class is set[2],
  * the item will not be selectable.
  *
- * [*] Note that using "aria-disabled" is preferred over the "disabled" class for better compatibility
+ * [1] state for checkbox items is not handled by weasel. When marking an item as menuitemcheckbox,
+ * you must also set an "aria-checked" attribute to "true" or "false" that correctly reflects the state.
+ * Otherwise, people using tools like screen readers won't know the item's state!
+ *
+ * [2] Note that using "aria-disabled" is preferred over the "disabled" class for better compatibility
  * with assistive technologies.
  *
  * Further, if `dom.dataElem(elem, 'menuItemSelected', (yesNo: boolean, elem) => {})` is set, that

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -289,9 +289,8 @@ export class BaseMenu extends Disposable implements IPopupContent {
         onKeyDown({
           ArrowDown: () => this.nextIndex(),
           ArrowUp: () => this.prevIndex(),
-          ...options.isSubMenu ? {
-            ArrowLeft: () => ctl.close(0),
-          } : {},
+          ArrowLeft: options.isSubMenu ? () => ctl.close(0) : () => {},
+          ArrowRight: () => {}
         }),
         (el) => options.modifyContent?.(el, ctl)
       ),

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -211,6 +211,29 @@ export const menuItemCheckbox = (checked: Observable<boolean>, ...args: DomEleme
 }
 
 /**
+ * A version of menuItem that's an <a> link element.
+ */
+export function menuItemLink(...args: DomElementArg[]): Element {
+  const preventActionIfDisabled = (ev: Event, item: HTMLElement) => {
+    if (isDisabled(item)) {
+      ev.preventDefault();
+      return;
+    }
+  }
+  return cssMenuItemLink(
+    {tabindex: '-1', role: 'menuitem'},
+    cssMenuItem.cls(''),
+    ...args,
+    dom.on('click', preventActionIfDisabled),
+    // This prevents propagation, but NOT the default action, which is to open the link.
+    onKeyDown({Enter$: (ev, item) => {
+      ev.stopPropagation();
+      return preventActionIfDisabled(ev, item);
+    }})
+  );
+}
+
+/**
  * A group of menu items with a visible heading, that is correctly announced
  * by screen readers.
  *
@@ -236,29 +259,6 @@ export function menuGroup(heading: DomElementArg, ...args: DomElementArg[]): Ele
     },
     dom('div', {id: headingId, role: 'presentation'}, heading),
     ...args
-  );
-}
-
-/**
- * A version of menuItem that's an <a> link element.
- */
-export function menuItemLink(...args: DomElementArg[]): Element {
-  const preventActionIfDisabled = (ev: Event, item: HTMLElement) => {
-    if (isDisabled(item)) {
-      ev.preventDefault();
-      return;
-    }
-  }
-  return cssMenuItemLink(
-    {tabindex: '-1', role: 'menuitem'},
-    cssMenuItem.cls(''),
-    ...args,
-    dom.on('click', preventActionIfDisabled),
-    // This prevents propagation, but NOT the default action, which is to open the link.
-    onKeyDown({Enter$: (ev, item) => {
-      ev.stopPropagation();
-      return preventActionIfDisabled(ev, item);
-    }})
   );
 }
 

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -4,7 +4,8 @@
  *
  * The standard menu item offers enough flexibility to suffice for many needs, and may be replaced
  * entirely by a custom item. For an item to be a selectable menu item, it needs `tabindex=-1`
- * attribute set. If unset, or if "aria-disabled" is set to "true", or if the "disabled" class is set[*],
+ * attribute set, and a role of either "menuitem", "menuitemcheckbox", or "option" (for selects).
+ * If there is no tabindex or role, if "aria-disabled" is set to "true", or if the "disabled" class is set[*],
  * the item will not be selectable.
  *
  * [*] Note that using "aria-disabled" is preferred over the "disabled" class for better compatibility
@@ -142,6 +143,7 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
  */
 export function menuItem(action: (item: HTMLElement, ev: Event) => void, ...args: DomElementArg[]): Element {
   return cssMenuItem(
+    {role: 'menuitem'},
     ...args,
     dom.on('click', (ev, elem) => {
       const item = findMenuItem(elem);
@@ -176,11 +178,23 @@ export function menuItem(action: (item: HTMLElement, ev: Event) => void, ...args
   );
 }
 
+export function menuGroup(heading: DomElementArg, ...args: DomElementArg[]): Element {
+  const headingId = uniqueId(weaselIdPrefix);
+  return cssMenuGroup(
+    {
+      role: 'group',
+      'aria-labelledby': headingId,
+    },
+    dom('div', {id: headingId, role: 'presentation'}, heading),
+    ...args
+  );
+}
+
 /**
  * A version of menuItem that's an <a> link element.
  */
 export function menuItemLink(...args: DomElementArg[]): Element {
-  return cssMenuItemLink({tabindex: '-1'}, cssMenuItem.cls(''), ...args,
+  return cssMenuItemLink({tabindex: '-1', role: 'menuitem'}, cssMenuItem.cls(''), ...args,
     // This prevents propagation, but NOT the default action, which is to open the link.
     onKeyDown({Enter$: (ev) => ev.stopPropagation()})
   );
@@ -315,19 +329,27 @@ export class BaseMenu extends Disposable implements IPopupContent {
   }
 
   protected nextIndex(): void {
-    if (!this._hasSelectables()) { return; }
+    const selectables = this._getSelectables();
+    if (!selectables.length) { return; }
     const next = this._getNextSelectable(
-      this._selected, (elem) => elem.nextElementSibling, this._menuContent.firstElementChild
+      this._selected, (elem) => this._findSibling(elem, selectables, 'next'), selectables[0]
     );
     this.setSelected(next);
   }
 
   protected prevIndex(): void {
-    if (!this._hasSelectables()) { return; }
+    const selectables = this._getSelectables();
+    if (!selectables.length) { return; }
     const next = this._getNextSelectable(
-      this._selected, (elem) => elem.previousElementSibling, this._menuContent.lastElementChild
+      this._selected, (elem) => this._findSibling(elem, selectables, 'prev'), selectables[selectables.length - 1]
     );
     this.setSelected(next);
+  }
+
+  private _findSibling(elem: Element | null, selectables: Element[], direction: 'next' | 'prev'): Element | null {
+    if (!elem) { return null; }
+    const index = selectables.indexOf(elem);
+    return selectables[index + (direction === 'next' ? 1 : -1)];
   }
 
   // When the selected element changes, update the classes of the formerly and newly-selected
@@ -376,8 +398,13 @@ export class BaseMenu extends Disposable implements IPopupContent {
     return elem && isSelectable(elem) ? elem : null;
   }
 
-  private _hasSelectables() {
-    return Array.from(this._menuContent.children).some(child => isSelectable(child));
+  private _getSelectables() {
+    const selectables = this._menuContent.querySelectorAll(
+      ':is([role="menuitem"], [role="menuitemcheckbox"], [role="option"]):not([aria-disabled="true"], .disabled)'
+    );
+    return Array.from(selectables).filter(child =>
+      (child as HTMLElement).offsetHeight > 0
+    );
   }
 
   /**
@@ -408,12 +435,6 @@ export class BaseMenu extends Disposable implements IPopupContent {
 export class Menu extends BaseMenu implements IPopupContent {
   constructor(ctl: IOpenController, items: DomElementArg[], options: IMenuOptions = {}) {
     super(ctl, items, options);
-    for (const child of this._menuContent.children) {
-      const existingRole = child.getAttribute('role');
-      if (!existingRole) {
-        child.setAttribute('role', 'menuitem');
-      }
-    }
     updateListAria(this, ctl.getTriggerElem(), this._menuContent, {role: 'menu'});
 
     setTimeout(() =>
@@ -528,6 +549,8 @@ export function menuItemSubmenu(
     options.expandIcon ? options.expandIcon() : cssExpandIcon(),
     dom.autoDispose(ctl),
 
+    {role: 'menuitem'},
+
     // Set the submenu to be attached as a child of this element rather than as a sibling.
     menu(submenu, popupOptions),
 
@@ -598,6 +621,13 @@ export const cssMenuItem = styled('li', `
     color: grey;
   }
 `);
+
+export const cssMenuGroup = styled('div', `
+  & [role="presentation"] {
+    text-transform: var(--weaseljs-menu-group-text-transform, uppercase);
+    padding: var(--weaseljs-menu-item-padding, 8px 24px);
+  }
+`)
 
 export const cssMenuItemLink = styled('a', `
   display: flex;

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -17,6 +17,7 @@ import {dom, domDispose, DomElementArg, DomElementMethod, DomMethod, EventCB, ID
 import {Disposable, onKeyDown, onKeyElem} from 'grainjs';
 import defaultsDeep = require('lodash/defaultsDeep');
 import mergeWith = require('lodash/mergeWith');
+import uniqueId = require('lodash/uniqueId');
 import {IOpenController, IPopupContent, IPopupOptions, PopupControl, setPopupToFunc} from './popup';
 import {ISelectOptions} from './select';
 
@@ -64,6 +65,8 @@ export interface ISubMenuOptions {
   action?: (item: HTMLElement, event: Event) => void; // If provided, called when the item is clicked.
 }
 
+const weaselIdPrefix = 'weasel-element-';
+
 /**
  * Attaches a menu to its trigger element, for example:
  *    dom('div', 'Open menu', menu((ctl) => [
@@ -85,6 +88,9 @@ export function menuElem(triggerElem: Element, createFunc: MenuCreateFunc, optio
     if (!triggerElem.getAttribute('tabindex')) {
       triggerElem.setAttribute('tabindex', '0');
     }
+  }
+  if (!triggerElem.id) {
+    triggerElem.id = uniqueId(weaselIdPrefix);
   }
   return baseElem((...args) => Menu.create(...args), triggerElem, createFunc, options);
 }
@@ -158,15 +164,6 @@ export const defaultMenuOptions: IMenuOptions = {
   },
 };
 
-const menuListIdPrefix = 'weasel-menu-list-';
-
-export function generateMenuListId(): string {
-  for (let i = 0; ; i++) {
-    if (!document.getElementById(menuListIdPrefix + i)) {
-      return menuListIdPrefix + i;
-    }
-  }
-}
 
 /**
  * Update the few ARIA attributes related to toggling on/off a menu popup related to a trigger element.
@@ -177,7 +174,7 @@ export function updateListAria(
   listElem: HTMLElement,
   options: { role: 'menu' | 'listbox' },
 ): string {
-  const listId = generateMenuListId();
+  const listId = uniqueId(weaselIdPrefix);
   listElem.id = listId;
   listElem.setAttribute('role', options.role);
   if (options.role === 'listbox') {
@@ -349,10 +346,10 @@ export class BaseMenu extends Disposable implements IPopupContent {
 export class Menu extends BaseMenu implements IPopupContent {
   constructor(ctl: IOpenController, items: DomElementArg[], options: IMenuOptions = {}) {
     super(ctl, items, options);
-
     Array.from(this._menuContent.children).forEach(child => {
       child.setAttribute('role', 'menuitem');
     });
+    this._menuContent.setAttribute('aria-labelledby', ctl.getTriggerElem().id);
     updateListAria(this, ctl.getTriggerElem(), this._menuContent, {role: 'menu'});
 
     setTimeout(() =>

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -378,8 +378,9 @@ export class BaseMenu extends Disposable implements IPopupContent {
 
   private _onMouseOver(ev: MouseEvent) {
     if (!isMenuContainer(ev.target as Element)) {
-      const elem = this._findTargetItem(ev);
-      this.setSelected(elem);     // If elem is null, intentionally deselect.
+      // If we don't find an item or it's not selectable, intentionally deselect.
+      const elem = findMenuItem(ev.target as Element);
+      this.setSelected(elem && isSelectable(elem) ? elem : null);
     }
   }
 
@@ -389,12 +390,6 @@ export class BaseMenu extends Disposable implements IPopupContent {
       // Don't deselect if there is an open submenu.
       this.setSelected(null);
     }
-  }
-
-  private _findTargetItem(ev: MouseEvent): HTMLElement|null {
-    // Find immediate child of this._menuContent which is an ancestor of ev.target.
-    const elem = findAncestorChild(this._menuContent, ev.target as Element);
-    return elem && isSelectable(elem) ? elem : null;
   }
 
   private _getSelectables() {
@@ -474,29 +469,21 @@ function isSelectable(elem: Element): elem is HTMLElement {
     (elem as HTMLElement).offsetHeight > 0;
 }
 
+/**
+ * Finds the menu item (role menuitem / menuitemcheckbox / option) that contains elem,
+ * within its nearest menu. Items may be nested inside groups, so this is not necessarily
+ * a direct child of the menu container.
+ */
 function findMenuItem(elem: Element) {
-  return findAncestorChild(elem.closest('.' + cssMenu.className)!, elem);
+  return elem.closest(`.${cssMenu.className} :is([role="menuitem"], [role="menuitemcheckbox"], [role="option"])`);
 }
 
 /**
  * Whether the given element is part of a selectable item. A click on it will close menus.
  */
 function isInSelectableItem(elem: Element): boolean {
-  // Similar to _findTargetItem, but finds the menu item (direct child of cssMenu) containing
-  // elem, regardless of which menu or submenu it's in, and returns whether it's selectable.
   const item = findMenuItem(elem);
   return item ? isSelectable(item) : false;
-}
-
-/**
- * Helper function which returns the direct child of ancestor which is an ancestor of elem, or
- * null if elem is not a descendant of ancestor.
- */
-function findAncestorChild(ancestor: Element, elem: Element|null): Element|null {
-  while (elem && elem.parentElement !== ancestor) {
-    elem = elem.parentElement;
-  }
-  return elem;
 }
 
 /**

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -220,9 +220,22 @@ export function menuGroup(heading: DomElementArg, ...args: DomElementArg[]): Ele
  * A version of menuItem that's an <a> link element.
  */
 export function menuItemLink(...args: DomElementArg[]): Element {
-  return cssMenuItemLink({tabindex: '-1', role: 'menuitem'}, cssMenuItem.cls(''), ...args,
+  const preventActionIfDisabled = (ev: Event, item: HTMLElement) => {
+    if (isDisabled(item)) {
+      ev.preventDefault();
+      return;
+    }
+  }
+  return cssMenuItemLink(
+    {tabindex: '-1', role: 'menuitem'},
+    cssMenuItem.cls(''),
+    ...args,
+    dom.on('click', preventActionIfDisabled),
     // This prevents propagation, but NOT the default action, which is to open the link.
-    onKeyDown({Enter$: (ev) => ev.stopPropagation()})
+    onKeyDown({Enter$: (ev, item) => {
+      ev.stopPropagation();
+      return preventActionIfDisabled(ev, item);
+    }})
   );
 }
 
@@ -637,7 +650,9 @@ export const cssMenuItem = styled('li', `
     background-color: var(--weaseljs-selected-background-color, #5AC09C);
     color:            var(--weaseljs-selected-color, white);
   }
-  &.disabled, &[aria-disabled="true"] {
+  &.disabled, &[aria-disabled="true"],
+  &.disabled:hover, &[aria-disabled="true"]:hover,
+  &.disabled:focus, &[aria-disabled="true"]:focus {
     color: grey;
   }
 `);
@@ -664,6 +679,9 @@ export const cssMenuItemLink = styled('a', `
   }
   &.${cssMenuItem.className}-sel {
     color: var(--weaseljs-selected-color, white);
+  }
+  &.disabled, &[aria-disabled="true"] {
+    cursor: default;
   }
 `);
 

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -116,15 +116,20 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
     (objValue: any, srcValue: any) => Array.isArray(srcValue) ? srcValue : undefined);
 
   const isInput = triggerElem.tagName.toLowerCase() === 'input';
+  // We don't do anything for input menus as they require a different approach to work correctly with
+  // screen readers (not implemented).
   if (!isInput) {
+    if (!triggerElem.id) {
+      triggerElem.id = uniqueId(weaselIdPrefix);
+    }
+    // The aria-expanded attr makes screen readers (SR) announce that the button is expandable, when focus is on it.
+    // We don't want to announce that when the trigger is not a normal click/keypress, for example a contextmenu event.
+    // Otherwise SR users might try to activate the button with Enter and get confused why it doesn't work.
     const useExpandedAttr = options.trigger?.some(t =>
       t === "click" || isEqual(t, {keys: ['Enter']})
     );
     if (useExpandedAttr) {
       triggerElem.setAttribute('aria-expanded', 'false');
-    }
-    if (!triggerElem.id) {
-      triggerElem.id = uniqueId(weaselIdPrefix);
     }
   }
 
@@ -139,7 +144,7 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
  * The item is generated with tabindex="-1". To generate a menu item that is not selectable,
  * set its "aria-disabled" attribute to "true" with additional args.
  *
- * The appearance of the menuItem components can be changed by setting the followingcss variables
+ * The appearance of the menuItem components can be changed by setting the following css variables
  * in the parent project:
  *    --weaseljs-selected-background-color
  *    --weaseljs-selected-color
@@ -182,6 +187,23 @@ export function menuItem(action: (item: HTMLElement, ev: Event) => void, ...args
   );
 }
 
+/**
+ * A group of menu items with a visible heading, that is correctly announced
+ * by screen readers.
+ *
+ * You should use a menuGroup instead of manually building a menu
+ * that has a heading and menu items as siblings. Otherwise, screen readers won't correctly
+ * announce the items relationships to the user.
+ *
+ * Example:
+ *   menu(() => [
+ *     menuItem(() => {}, 'Ungrouped item'),
+ *     menuGroup('Grouped items header',
+ *       menuItem(() => {}, 'Grouped item 1'),
+ *       menuItem(() => {}, 'Grouped item 2'),
+ *     ),
+ *   ]),
+ */
 export function menuGroup(heading: DomElementArg, ...args: DomElementArg[]): Element {
   const headingId = uniqueId(weaselIdPrefix);
   return cssMenuGroup(
@@ -223,7 +245,7 @@ export const defaultMenuOptions: IMenuOptions = {
  * Update the few ARIA attributes related to toggling on/off a menu popup related to a trigger element.
  */
 export function updateListAria(
-  menu: BaseMenu,
+  owner: BaseMenu,
   triggerElem: Element,
   listElem: HTMLElement,
   options: { role: 'menu' | 'listbox' },
@@ -234,6 +256,8 @@ export function updateListAria(
   if (options.role === 'listbox') {
     listElem.setAttribute('aria-orientation', 'vertical');
   }
+  // The aria-expanded attribute is not always set on the trigger button, in case of a contextmenu trigger for example
+  // (see comment in `baseElem` above). Make sure to not add it by mistake in that case.
   if (triggerElem.hasAttribute('aria-expanded')) {
     triggerElem.setAttribute('aria-expanded', 'true');
   }
@@ -242,7 +266,8 @@ export function updateListAria(
   if (options.role === 'menu' && triggerElem.id && !listElem.getAttribute('aria-labelledby')) {
     listElem.setAttribute('aria-labelledby', triggerElem.id);
   }
-  menu.onDispose(() => {
+  owner.onDispose(() => {
+    // See comment above when setting the aria-expanded attribute.
     if (triggerElem.hasAttribute('aria-expanded')) {
       triggerElem.setAttribute('aria-expanded', 'false');
     }
@@ -294,6 +319,7 @@ export class BaseMenu extends Disposable implements IPopupContent {
           ArrowDown: () => this.nextIndex(),
           ArrowUp: () => this.prevIndex(),
           ArrowLeft: options.isSubMenu ? () => ctl.close(0) : () => {},
+          // We disable the right arrow key in case a global shortcut bound to it would collide
           ArrowRight: () => {}
         }),
         (el) => options.modifyContent?.(el, ctl)

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -305,9 +305,9 @@ export class BaseMenu extends Disposable implements IPopupContent {
           ev.stopPropagation();
         }
       }),
-      options.isSubMenu ? null :
-        onKeyDown({
-          Escape: () => ctl.close(0),
+      onKeyDown({
+        Escape: () => ctl.close(0),
+        ...(options.isSubMenu ? {} : {
           Enter: () => ctl.close(0),    // gets bubbled key after action is taken.
           // prevent using the Tab key to navigate: we use arrow keys
           Tab: (ev) => {
@@ -315,6 +315,7 @@ export class BaseMenu extends Disposable implements IPopupContent {
             ev.stopPropagation();
           },
         }),
+      }),
     );
     this.onDispose(() => domDispose(this.content));
   }

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -250,8 +250,9 @@ export function updateListAria(
   listElem: HTMLElement,
   options: { role: 'menu' | 'listbox' },
 ) {
-  const listId = uniqueId(weaselIdPrefix);
-  listElem.id = listId;
+  if (!listElem.id) {
+    listElem.id = uniqueId(weaselIdPrefix);
+  }
   listElem.setAttribute('role', options.role);
   if (options.role === 'listbox') {
     listElem.setAttribute('aria-orientation', 'vertical');
@@ -261,8 +262,8 @@ export function updateListAria(
   if (triggerElem.hasAttribute('aria-expanded')) {
     triggerElem.setAttribute('aria-expanded', 'true');
   }
-  triggerElem.setAttribute('aria-controls', listId);
-  triggerElem.setAttribute('aria-owns', listId);
+  triggerElem.setAttribute('aria-controls', listElem.id);
+  triggerElem.setAttribute('aria-owns', listElem.id);
   if (options.role === 'menu' && triggerElem.id && !listElem.getAttribute('aria-labelledby')) {
     listElem.setAttribute('aria-labelledby', triggerElem.id);
   }

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -168,6 +168,7 @@ export function menuItem(action: (item: HTMLElement, ev: Event) => void, ...args
       // Space key is used to toggle a checkbox item without closing the parent menu.
       " $": (ev, elem) => {
         if (elem.getAttribute('role') === 'menuitemcheckbox') {
+          ev.preventDefault();
           action(elem, ev);
         }
       }

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -310,6 +310,7 @@ export class BaseMenu extends Disposable implements IPopupContent {
   }
 
   protected nextIndex(): void {
+    if (!this._hasSelectables()) { return; }
     const next = this._getNextSelectable(
       this._selected, (elem) => elem.nextElementSibling, this._menuContent.firstElementChild
     );
@@ -317,6 +318,7 @@ export class BaseMenu extends Disposable implements IPopupContent {
   }
 
   protected prevIndex(): void {
+    if (!this._hasSelectables()) { return; }
     const next = this._getNextSelectable(
       this._selected, (elem) => elem.previousElementSibling, this._menuContent.lastElementChild
     );
@@ -367,6 +369,10 @@ export class BaseMenu extends Disposable implements IPopupContent {
     // Find immediate child of this._menuContent which is an ancestor of ev.target.
     const elem = findAncestorChild(this._menuContent, ev.target as Element);
     return elem && isSelectable(elem) ? elem : null;
+  }
+
+  private _hasSelectables() {
+    return Array.from(this._menuContent.children).some(child => isSelectable(child));
   }
 
   /**

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -75,6 +75,7 @@ export function menu(createFunc: MenuCreateFunc, options?: IMenuOptions): DomEle
   return (elem) => menuElem(elem, createFunc, options);
 }
 export function menuElem(triggerElem: Element, createFunc: MenuCreateFunc, options: IMenuOptions = {}) {
+  triggerElem.setAttribute('aria-expanded', 'false');
   // try to automatically fix potentially bad uses of trigger elements: make sure they are exposed as buttons
   // to assistive technologies, and reachable with the keyboard.
   if (triggerElem.tagName !== 'BUTTON') {
@@ -156,6 +157,42 @@ export const defaultMenuOptions: IMenuOptions = {
     computeStyle: {gpuAcceleration: false}
   },
 };
+
+const menuListIdPrefix = 'weasel-menu-list-';
+
+export function generateMenuListId(): string {
+  for (let i = 0; ; i++) {
+    if (!document.getElementById(menuListIdPrefix + i)) {
+      return menuListIdPrefix + i;
+    }
+  }
+}
+
+/**
+ * Update the few ARIA attributes related to toggling on/off a menu popup related to a trigger element.
+ */
+export function updateListAria(
+  menu: BaseMenu,
+  triggerElem: Element,
+  listElem: HTMLElement,
+  options: { role: 'menu' | 'listbox' },
+): string {
+  const listId = generateMenuListId();
+  listElem.id = listId;
+  listElem.setAttribute('role', options.role);
+  if (options.role === 'listbox') {
+    listElem.setAttribute('aria-orientation', 'vertical');
+  }
+  triggerElem.setAttribute('aria-expanded', 'true');
+  triggerElem.setAttribute('aria-controls', listId);
+  triggerElem.setAttribute('aria-owns', listId);
+  menu.onDispose(() => {
+    triggerElem.setAttribute('aria-expanded', 'false');
+    triggerElem.removeAttribute('aria-controls');
+    triggerElem.removeAttribute('aria-owns');
+  });
+  return listId;
+}
 
 /**
  * Implementation of the BaseMenu. Extended by Menu and Select.
@@ -312,6 +349,11 @@ export class BaseMenu extends Disposable implements IPopupContent {
 export class Menu extends BaseMenu implements IPopupContent {
   constructor(ctl: IOpenController, items: DomElementArg[], options: IMenuOptions = {}) {
     super(ctl, items, options);
+
+    Array.from(this._menuContent.children).forEach(child => {
+      child.setAttribute('role', 'menuitem');
+    });
+    updateListAria(this, ctl.getTriggerElem(), this._menuContent, {role: 'menu'});
 
     setTimeout(() =>
       (options.selectOnOpen ? this.nextIndex() : this._menuContent.focus()), 0);

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -18,6 +18,7 @@ import {Disposable, onKeyDown, onKeyElem} from 'grainjs';
 import defaultsDeep = require('lodash/defaultsDeep');
 import mergeWith = require('lodash/mergeWith');
 import uniqueId = require('lodash/uniqueId');
+import isEqual = require('lodash/isEqual');
 import {IOpenController, IPopupContent, IPopupOptions, PopupControl, setPopupToFunc} from './popup';
 import {ISelectOptions} from './select';
 
@@ -78,10 +79,6 @@ export function menu(createFunc: MenuCreateFunc, options?: IMenuOptions): DomEle
   return (elem) => menuElem(elem, createFunc, options);
 }
 export function menuElem(triggerElem: Element, createFunc: MenuCreateFunc, options: IMenuOptions = {}) {
-  triggerElem.setAttribute('aria-expanded', 'false');
-  if (!triggerElem.id) {
-    triggerElem.id = uniqueId(weaselIdPrefix);
-  }
   return baseElem((...args) => Menu.create(...args), triggerElem, createFunc, options);
 }
 
@@ -108,6 +105,20 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
   // the exact value from options if present.
   options = mergeWith({}, defaultMenuOptions, options,
     (objValue: any, srcValue: any) => Array.isArray(srcValue) ? srcValue : undefined);
+
+  const isInput = triggerElem.tagName.toLowerCase() === 'input';
+  if (!isInput) {
+    const useExpandedAttr = options.trigger?.some(t =>
+      t === "click" || isEqual(t, {keys: ['Enter']})
+    );
+    if (useExpandedAttr) {
+      triggerElem.setAttribute('aria-expanded', 'false');
+    }
+    if (!triggerElem.id) {
+      triggerElem.id = uniqueId(weaselIdPrefix);
+    }
+  }
+
   setPopupToFunc(triggerElem,
     (ctl, opts) => createFn(null, ctl, createFunc(ctl), defaultsDeep(opts, options)),
     options);
@@ -163,25 +174,28 @@ export function updateListAria(
   triggerElem: Element,
   listElem: HTMLElement,
   options: { role: 'menu' | 'listbox' },
-): string {
+) {
   const listId = uniqueId(weaselIdPrefix);
   listElem.id = listId;
   listElem.setAttribute('role', options.role);
   if (options.role === 'listbox') {
     listElem.setAttribute('aria-orientation', 'vertical');
   }
-  triggerElem.setAttribute('aria-expanded', 'true');
+  if (triggerElem.hasAttribute('aria-expanded')) {
+    triggerElem.setAttribute('aria-expanded', 'true');
+  }
   triggerElem.setAttribute('aria-controls', listId);
   triggerElem.setAttribute('aria-owns', listId);
   if (options.role === 'menu' && triggerElem.id) {
     listElem.setAttribute('aria-labelledby', triggerElem.id);
   }
   menu.onDispose(() => {
-    triggerElem.setAttribute('aria-expanded', 'false');
+    if (triggerElem.hasAttribute('aria-expanded')) {
+      triggerElem.setAttribute('aria-expanded', 'false');
+    }
     triggerElem.removeAttribute('aria-controls');
     triggerElem.removeAttribute('aria-owns');
   });
-  return listId;
 }
 
 /**

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -409,7 +409,7 @@ export class Menu extends BaseMenu implements IPopupContent {
     super(ctl, items, options);
     for (const child of this._menuContent.children) {
       const existingRole = child.getAttribute('role');
-      if (!existingRole || !['menuitem', 'menuitemcheckbox'].includes(existingRole)) {
+      if (!existingRole) {
         child.setAttribute('role', 'menuitem');
       }
     }

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -365,9 +365,10 @@ export class BaseMenu extends Disposable implements IPopupContent {
       ),
       // Events set on the parent of _menuContent receive events bubbled up from submenus.
       dom.on('click', (ev) => {
-        if (isInSelectableItem(ev.target as Element)) {
+        const item = findMenuItem(ev.target as Element);
+        if (item && isSelectable(item)) {
           // Items might be checkboxes, in that case we don't want to close the menu on click
-          if (findMenuItem(ev.target as Element)?.getAttribute('role') !== 'menuitemcheckbox') {
+          if (item.getAttribute('role') !== 'menuitemcheckbox') {
             ctl.close(0);
           }
         } else {
@@ -548,14 +549,6 @@ function isDisabled(elem: Element): boolean {
  */
 function findMenuItem(elem: Element) {
   return elem.closest(`.${cssMenu.className} :is([role="menuitem"], [role="menuitemcheckbox"], [role="option"])`);
-}
-
-/**
- * Whether the given element is part of a selectable item. A click on it will close menus.
- */
-function isInSelectableItem(elem: Element): boolean {
-  const item = findMenuItem(elem);
-  return item ? isSelectable(item) : false;
 }
 
 /**

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -8,11 +8,10 @@
  * If there is no tabindex or role, if "aria-disabled" is set to "true", or if the "disabled" class is set[2],
  * the item will not be selectable.
  *
- * [1] state for checkbox items is not handled by weasel. When marking an item as menuitemcheckbox,
- * you must also set an "aria-checked" attribute to "true" or "false" that correctly reflects the state.
- * Otherwise, people using tools like screen readers won't know the item's state!
+ * [1] you should use the `menuItemCheckbox` helper to build checkbox menu items to make sure they are
+ * compatible with assistive technologies.
  *
- * [2] Note that using "aria-disabled" is preferred over the "disabled" class for better compatibility
+ * [2] Note that using "aria-disabled" is preferred over the "disabled" class for compatibility
  * with assistive technologies.
  *
  * Further, if `dom.dataElem(elem, 'menuItemSelected', (yesNo: boolean, elem) => {})` is set, that
@@ -22,7 +21,7 @@
  * Clicks on items will normally propagate to the menu, where they get caught and close the menu.
  * If a click on an item should not close the menu, the item should stop the click's propagation.
  */
-import {dom, domDispose, DomElementArg, DomElementMethod, DomMethod, EventCB, styled} from 'grainjs';
+import {dom, domDispose, DomElementArg, DomElementMethod, DomMethod, EventCB, Observable, styled} from 'grainjs';
 import {Disposable, onKeyDown, onKeyElem} from 'grainjs';
 import defaultsDeep = require('lodash/defaultsDeep');
 import mergeWith = require('lodash/mergeWith');
@@ -151,37 +150,61 @@ function baseElem(createFn: MenuClassCons, triggerElem: Element, createFunc: Men
  *    --weaseljs-menu-item-padding
  */
 export function menuItem(action: (item: HTMLElement, ev: Event) => void, ...args: DomElementArg[]): Element {
+  const triggerAction = (ev: Event, item: HTMLElement) => {
+    if (isDisabled(item)) {
+      ev.preventDefault();
+    } else {
+      action(item, ev);
+    }
+  }
   return cssMenuItem(
     {role: 'menuitem'},
     ...args,
-    dom.on('click', (ev, elem) => {
-      const item = findMenuItem(elem);
-      if (item?.classList.contains('disabled') || item?.getAttribute('aria-disabled') === 'true') {
-        return;
-      }
-      const isCheckbox = item?.getAttribute('role') === 'menuitemcheckbox'
-        && (ev.target as HTMLElement).tagName.toLowerCase() === 'input'
-        && (ev.target as HTMLInputElement).type === 'checkbox';
-      // If we click a checkbox inside a menuitemcheckbox, we assume we want the checkbox to be visually toggled, so
-      // we let default behavior occur. Without this exception, clicking the checkbox itself would not update its UI.
-      // Otherwise, make sure to prevent default element action to avoid issues (e.g. clicking a label triggers
-      // a click on the tied input, and we don't want that).
-      if (!isCheckbox) {
-        ev.preventDefault();
-      }
-      action(elem, ev);
-    }),
+    dom.on('click', triggerAction),
+    // `tabindex="-1"` is automatically added by the onKeyDown helper, making the item selectable by default.
+    onKeyDown({ "Enter$": triggerAction })
+  );
+}
+
+/**
+ * A toggleable menu item.
+ *
+ * This makes sure screen readers correctly announce the menu item as checked/unchecked.
+ * You are expected to provide your own UI that reflects the observable as the item content.
+ * A classic checkbox input element tied to the observable can be used.
+ *
+ * The item is generated with tabindex="-1". To generate a menu item that is not selectable,
+ * set its "aria-disabled" attribute to "true" through the additional args.
+ */
+export const menuItemCheckbox = (checked: Observable<boolean>, ...args: DomElementArg[]) => {
+  const toggle = (ev: Event, item: HTMLElement) => {
+    if (isDisabled(item)) {
+      ev.preventDefault();
+      return;
+    }
+    // UI provided has chances to be a classic label+input pair. In that case, we prevent default's browser behavior
+    // if we click the label.
+    // Without this, browser triggers a programmatic click event on the input when clicking the label. Our click
+    // listener would be triggered twice, once for the label, once for the input, resulting in the `checked`
+    // observable being toggled twice with one actual user click.
+    if (ev.target instanceof HTMLElement && ev.target.closest('label') !== null && ev.target.tagName !== 'INPUT') {
+      ev.preventDefault();
+    }
+    checked.set(!checked.get());
+  }
+  return cssMenuItem(
+    {role: 'menuitemcheckbox'},
+    dom.attr("aria-checked", use => use(checked) ? "true" : "false"),
+    ...args,
+    dom.on('click', toggle),
     // `tabindex="-1"` is automatically added by the onKeyDown helper, making the item selectable by default.
     onKeyDown({
-      "Enter$": (ev, elem) => {
-        action(elem, ev)
-      },
+      "Enter$": toggle,
       // Space key is used to toggle a checkbox item without closing the parent menu.
-      " $": (ev, elem) => {
-        if (elem.getAttribute('role') === 'menuitemcheckbox') {
+      " $": (ev, item) => {
+          // We always prevent default here to prevent browser from scrolling.
           ev.preventDefault();
-          action(elem, ev);
-        }
+          toggle(ev, item);
       }
     })
   );

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -79,16 +79,6 @@ export function menu(createFunc: MenuCreateFunc, options?: IMenuOptions): DomEle
 }
 export function menuElem(triggerElem: Element, createFunc: MenuCreateFunc, options: IMenuOptions = {}) {
   triggerElem.setAttribute('aria-expanded', 'false');
-  // try to automatically fix potentially bad uses of trigger elements: make sure they are exposed as buttons
-  // to assistive technologies, and reachable with the keyboard.
-  if (triggerElem.tagName !== 'BUTTON') {
-    if (!triggerElem.getAttribute('role')) {
-      triggerElem.setAttribute('role', 'button');
-    }
-    if (!triggerElem.getAttribute('tabindex')) {
-      triggerElem.setAttribute('tabindex', '0');
-    }
-  }
   if (!triggerElem.id) {
     triggerElem.id = uniqueId(weaselIdPrefix);
   }

--- a/lib/select.ts
+++ b/lib/select.ts
@@ -222,7 +222,11 @@ const cssBtnText = styled('div', `
   text-overflow: ellipsis;
 `);
 
-const cssSelectBtn = styled('div', `
+const cssSelectBtn = styled('button', `
+  margin: 0;
+  font: inherit;
+  letter-spacing: inherit;
+  opacity: 1;
   position: relative;
   display: flex;
   justify-content: space-between;

--- a/lib/select.ts
+++ b/lib/select.ts
@@ -119,18 +119,16 @@ export function select<T>(
       const selected = obj.value === obs.get();
       return menuItem(
         () => { obs.set(obj.value); },
-        Object.assign(
-          {
-            disabled: obj.disabled,
-            selected,
-            // aria attrs expect specific values as strings so we can't directly
-            // rely on `obj.disabled` or `selected` as values
-            'aria-disabled': obj.disabled ? "true" : undefined,
-            'aria-selected': selected ? "true" : "false",
-            role: 'option'
-          },
-          obj.disabled ? {class: 'disabled'} : {}
-        ),
+        {
+          disabled: obj.disabled,
+          ...(obj.disabled ? {class: 'disabled'} : {}),
+          selected,
+          // aria attrs expect specific values as strings so we can't directly
+          // rely on `obj.disabled` or `selected` as values
+          'aria-disabled': obj.disabled ? "true" : undefined,
+          'aria-selected': selected ? "true" : "false",
+          role: 'option',
+        },
         renderOption(obj)
       );
     })

--- a/lib/select.ts
+++ b/lib/select.ts
@@ -1,6 +1,6 @@
 import {dom, DomArg, DomContents, DomElementArg, onElem, styled} from 'grainjs';
 import {BindableValue, Computed, MaybeObsArray, Observable} from 'grainjs';
-import {BaseMenu, defaultMenuOptions, IMenuOptions, menuItem} from './menu';
+import {BaseMenu, updateListAria, defaultMenuOptions, IMenuOptions, menuItem} from './menu';
 import {IOpenController, IPopupOptions, PopupControl, setPopupToFunc} from './popup';
 
 export interface IOptionFull<T> {
@@ -68,7 +68,13 @@ export function select<T>(
   });
 
   // Select button and associated event/disposal DOM.
-  const selectBtn: HTMLElement = cssSelectBtn({tabIndex: '0', class: options.buttonCssClass || ''},
+  const selectBtn: HTMLElement = cssSelectBtn(
+    {
+      tabIndex: '0',
+      class: options.buttonCssClass || '',
+      'aria-haspopup': 'listbox',
+      'aria-expanded': 'false',
+    },
     dom.autoDispose(selected),
     options.disabled ? dom.cls('disabled', options.disabled) : null,
     cssBtnText(
@@ -110,9 +116,21 @@ export function select<T>(
       const obj: IOptionFull<T> = getOptionFull(option);
       // Note we only set 'selected' when an <option> is created; we are not subscribing to obs.
       // This is to reduce the amount of subscriptions, esp. when number of options is large.
-      return menuItem(() => { obs.set(obj.value); },
-        Object.assign({disabled: obj.disabled, selected: obj.value === obs.get()},
-          obj.disabled ? {class: 'disabled'} : {}),
+      const selected = obj.value === obs.get();
+      return menuItem(
+        () => { obs.set(obj.value); },
+        Object.assign(
+          {
+            disabled: obj.disabled,
+            selected,
+            // aria attrs expect specific values as strings so we can't directly
+            // rely on `obj.disabled` or `selected` as values
+            'aria-disabled': obj.disabled ? "true" : undefined,
+            'aria-selected': selected ? "true" : "false",
+            role: 'option'
+          },
+          obj.disabled ? {class: 'disabled'} : {}
+        ),
         renderOption(obj)
       );
     })
@@ -146,6 +164,8 @@ class Select<T> extends BaseMenu {
 
   constructor(ctl: IOpenController, items: DomElementArg[], options: ISelectOptions = {}) {
     super(ctl, items, options);
+
+    updateListAria(this, ctl.getTriggerElem(), this._menuContent, {role: 'listbox'});
 
     // On keydown, search for the first element with a matching label.
     onElem(this._menuContent, 'keydown', (ev) => {

--- a/lib/select.ts
+++ b/lib/select.ts
@@ -96,7 +96,8 @@ export function select<T>(
       dom.onElem(triggerElem, 'click', () => isDisabled() || ctl.toggle());
       dom.onKeyElem(triggerElem as HTMLElement, 'keydown', {
         ArrowDown: () => isDisabled() || ctl.open(),
-        ArrowUp: () => isDisabled() || ctl.open()
+        ArrowUp: () => isDisabled() || ctl.open(),
+        Enter: () => isDisabled() || ctl.open(),
       });
     }],
     selectLabelOnOpen: () => selected.get().label,

--- a/lib/select.ts
+++ b/lib/select.ts
@@ -167,6 +167,7 @@ class Select<T> extends BaseMenu {
 
     // On keydown, search for the first element with a matching label.
     onElem(this._menuContent, 'keydown', (ev) => {
+      if (ev.getModifierState('Control') || ev.getModifierState('Alt') || ev.getModifierState('Meta')) { return; }
       const sel = this._keyState.add(ev.key);
       if (sel) { this._selectRow(sel.label); }
     });

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -25,11 +25,14 @@ describe('menu', () => {
 
     assert.equal(await trigger.getAttribute('aria-expanded'), 'true');
     const listId = await trigger.getAttribute('aria-controls');
-    assert.match(listId!, /^weasel-menu-list-\d+$/);
+    assert.match(listId!, /^weasel-element-\d+$/);
     assert.equal(await trigger.getAttribute('aria-owns'), listId);
 
     const list = await driver.find(`#${listId}`);
     assert.equal(await list.getAttribute('role'), 'menu');
+
+    const triggerId = await trigger.getAttribute('id');
+    assert.equal(await list.getAttribute('aria-labelledby'), triggerId);
 
     const menuItem = await driver.find('.test-cut');
     assert.equal(await menuItem.getAttribute('role'), 'menuitem');

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -230,9 +230,14 @@ describe('menu', () => {
     await driver.sendKeys(Key.UP);
     assert.equal(await driver.find('.test-sub-item-checkbox').hasFocus(), true);
 
-    // ESCAPE should close both menus.
+    // ESCAPE should close only the submenu; parent stays open.
     await driver.sendKeys(Key.ESCAPE);
     await assertOpen('.test-submenu1', false);
+    await assertOpen('.test-menu1', true);
+    assert.equal(await driver.find('.test-sub-item').hasFocus(), true);
+
+    // ESCAPE again should close the parent menu.
+    await driver.sendKeys(Key.ESCAPE);
     await assertOpen('.test-menu1', false);
     // No actions were performed.
     assert.equal(await driver.find('.test-last').getText(), '');

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -15,6 +15,33 @@ describe('menu', () => {
     await driver.find('.test-reset').click();
   });
 
+  it('should use ARIA attributes', async function() {
+    const trigger = await driver.find('.test-btn1');
+    assert.equal(await trigger.getAttribute('aria-expanded'), 'false');
+    assert.notOk(await trigger.getAttribute('aria-controls'));
+
+    await trigger.click();
+    await assertOpen('.test-menu1', true);
+
+    assert.equal(await trigger.getAttribute('aria-expanded'), 'true');
+    const listId = await trigger.getAttribute('aria-controls');
+    assert.match(listId!, /^weasel-menu-list-\d+$/);
+    assert.equal(await trigger.getAttribute('aria-owns'), listId);
+
+    const list = await driver.find(`#${listId}`);
+    assert.equal(await list.getAttribute('role'), 'menu');
+
+    const menuItem = await driver.find('.test-cut');
+    assert.equal(await menuItem.getAttribute('role'), 'menuitem');
+    assert.equal(await menuItem.getAttribute('tabindex'), '-1');
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-menu1', false);
+    assert.equal(await trigger.getAttribute('aria-expanded'), 'false');
+    assert.notOk(await trigger.getAttribute('aria-controls'));
+    assert.notOk(await trigger.getAttribute('aria-owns'));
+  });
+
   it('should toggle on trigger click', async function() {
     // Open menu, check we see something.
     await driver.find('.test-btn1').click();

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -321,6 +321,22 @@ describe('menu', () => {
     assert.equal(await driver.find('.test-input1').getAttribute('value'), 'helloa');
   });
 
+  function findSelected() {
+    return driver.findAll('li[class*=-sel]', (e) => e.getText());
+  }
+
+  it('should not hang when navigating a menu of only disabled items', async function() {
+    await driver.find('.test-btn-only-disabled-items').click();
+    await assertOpen('.test-only-disabled-items-menu', true);
+    // Nothing should be selected; arrow keys must not loop forever.
+    await driver.sendKeys(Key.DOWN);
+    assert.deepEqual(await findSelected(), []);
+    await driver.sendKeys(Key.UP);
+    assert.deepEqual(await findSelected(), []);
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-only-disabled-items-menu', false);
+  });
+
   it('should allow nothing selected with navigating navigation', async function() {
     await driver.find('.test-btn5').click();
     await assertOpen('.test-menu1', true);
@@ -346,11 +362,6 @@ describe('menu', () => {
     await assertOpen('.test-menu1', true);
     await driver.sendKeys(Key.ESCAPE);
     await assertOpen('.test-menu1', false);
-
-    function findSelected() {
-      return driver.findAll('li[class*=-sel]', (e) => e.getText());
-    }
-
   });
 
   it('should support the modifyContent argument to customize the dropdown element', async function() {

--- a/test/browser/menu.ts
+++ b/test/browser/menu.ts
@@ -228,7 +228,7 @@ describe('menu', () => {
     await driver.sendKeys(Key.UP);
     assert.equal(await driver.find('.test-sub-item2').hasFocus(), true);
     await driver.sendKeys(Key.UP);
-    assert.equal(await driver.find('.test-paste2').hasFocus(), true);
+    assert.equal(await driver.find('.test-sub-item-checkbox').hasFocus(), true);
 
     // ESCAPE should close both menus.
     await driver.sendKeys(Key.ESCAPE);
@@ -251,6 +251,31 @@ describe('menu', () => {
     await assertOpen('.test-menu1', true);
     await driver.sendKeys(Key.ESCAPE);
     await assertOpen('.test-menu1', false);
+  });
+
+  it('should close submenu inside a group when another item is selected', async function() {
+    await driver.find('.test-btn-grouped-items').mouseMove().click();
+    await assertOpen('.test-grouped-items-menu', true);
+
+    // Mouse over a submenu item nested inside a menuGroup.
+    await driver.find('.test-grouped-sub-item').mouseMove();
+    await driver.findWait('.test-submenu1', 1000);
+    await assertOpen('.test-submenu1', true);
+
+    // Mouse over a sibling item in the same group — submenu should close.
+    await driver.find('.test-grouped-item1').mouseMove();
+    await assertOpen('.test-submenu1', false);
+    await assertOpen('.test-grouped-items-menu', true);
+
+    // Re-open, then hover an ungrouped sibling — submenu should close.
+    await driver.find('.test-grouped-sub-item').mouseMove();
+    await driver.findWait('.test-submenu1', 1000);
+    await assertOpen('.test-submenu1', true);
+    await driver.find('.test-ungrouped-item').mouseMove();
+    await assertOpen('.test-submenu1', false);
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-grouped-items-menu', false);
   });
 
   it('should support setOpenClass() while a menu is open', async function() {

--- a/test/browser/select.ts
+++ b/test/browser/select.ts
@@ -26,7 +26,7 @@ describe('select', () => {
 
     assert.equal(await trigger.getAttribute('aria-expanded'), 'true');
     const listId = await trigger.getAttribute('aria-controls');
-    assert.match(listId!, /^weasel-menu-list-\d+$/);
+    assert.match(listId!, /^weasel-element-\d+$/);
     assert.equal(await trigger.getAttribute('aria-owns'), listId);
 
     const list = await driver.find(`#${listId}`);

--- a/test/browser/select.ts
+++ b/test/browser/select.ts
@@ -1,5 +1,6 @@
 import {assert, driver, Key, useServer} from 'mocha-webdriver';
 import {server} from '../fixtures/webpack-test-server';
+import {assertOpen} from './utils';
 
 describe('select', () => {
   useServer(server);
@@ -11,6 +12,64 @@ describe('select', () => {
 
   beforeEach(async function() {
     await driver.find('.test-reset').click();
+  });
+
+  it('should use ARIA attributes', async function() {
+    const trigger = await driver.find('.test-btn3');
+    assert.equal((await trigger.getTagName()).toLowerCase(), 'button');
+    assert.equal(await trigger.getAttribute('aria-haspopup'), 'listbox');
+    assert.equal(await trigger.getAttribute('aria-expanded'), 'false');
+    assert.notOk(await trigger.getAttribute('aria-controls'));
+
+    await trigger.click();
+    await assertOpen('.test-select-dropdown', true);
+
+    assert.equal(await trigger.getAttribute('aria-expanded'), 'true');
+    const listId = await trigger.getAttribute('aria-controls');
+    assert.match(listId!, /^weasel-menu-list-\d+$/);
+    assert.equal(await trigger.getAttribute('aria-owns'), listId);
+
+    const list = await driver.find(`#${listId}`);
+    assert.equal(await list.getAttribute('role'), 'listbox');
+    assert.equal(await list.getAttribute('aria-orientation'), 'vertical');
+
+    const avocado = await driver.findContent('[role="option"]', /avocado/);
+    assert.equal(await avocado.getAttribute('role'), 'option');
+    assert.equal(await avocado.getAttribute('aria-selected'), 'true');
+
+    const apple = await driver.findContent('[role="option"]', /apple/);
+    assert.equal(await apple.getAttribute('aria-selected'), 'false');
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-select-dropdown', false);
+    assert.equal(await trigger.getAttribute('aria-expanded'), 'false');
+    assert.notOk(await trigger.getAttribute('aria-controls'));
+    assert.notOk(await trigger.getAttribute('aria-owns'));
+  });
+
+  it('should open on Enter key', async function() {
+    const trigger = await driver.find('.test-btn3');
+    await trigger.click();
+    await assertOpen('.test-select-dropdown', true);
+    await driver.sendKeys(Key.ESCAPE);
+    await assertOpen('.test-select-dropdown', false);
+
+    await driver.sendKeys(Key.ENTER);
+    await assertOpen('.test-select-dropdown', true);
+    assert.equal(await trigger.getAttribute('aria-expanded'), 'true');
+    await driver.sendKeys(Key.ESCAPE);
+  });
+
+  it('should expose aria-disabled on disabled options', async function() {
+    await driver.find('.test-btn4').click();
+    await assertOpen('.test-select-dropdown', true);
+    const bob = await driver.findContent('[role="option"]', /Bob/);
+    assert.isTrue(await bob.matches('.disabled'));
+    assert.equal(await bob.getAttribute('aria-disabled'), 'true');
+    const alice = await driver.findContent('[role="option"]', /Alice/);
+    assert.isNull(await alice.getAttribute('aria-disabled'));
+    await alice.click();
+    await assertOpen('.test-select-dropdown', false);
   });
 
   it('should open to selected element', async function() {

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -85,7 +85,7 @@ function setupTest() {
       menu(() => [
         testId('only-disabled-items-menu'),
         menuItem(() => {}, 'Disabled stuff', dom.cls('disabled')),
-        menuItem(() => {}, 'Disabled stuff', dom.cls('disabled')),
+        menuItem(() => {}, 'Disabled stuff', dom.attr('aria-disabled', 'true')),
         menuItem(() => {}, 'Disabled stuff', dom.cls('disabled')),
       ]),
     ),

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -298,6 +298,7 @@ function makeCheckboxItem(label: string, ...args: DomElementArg[]) {
     lastAction.set(`${label} toggle: ${checkboxObs.get()}`);
   }, [
     {role: 'menuitemcheckbox'},
+    dom.attr("aria-checked", use => use(checkboxObs) ? "true" : "false"),
     dom('label',
       dom('span', label),
       dom('span', dom('input',

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -79,6 +79,16 @@ function setupTest() {
         makeCheckboxItem('Checkbox 3'),
       ]),
     ),
+    cssButton('My Menu with only disabled items',
+      {tabindex: '0'},
+      testId('btn-only-disabled-items'),
+      menu(() => [
+        testId('only-disabled-items-menu'),
+        menuItem(() => {}, 'Disabled stuff', dom.cls('disabled')),
+        menuItem(() => {}, 'Disabled stuff', dom.cls('disabled')),
+        menuItem(() => {}, 'Disabled stuff', dom.cls('disabled')),
+      ]),
+    ),
     makeSelect(),
     makeComplexSelect(),
     cssInputContainer(

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -38,7 +38,7 @@ function setupTest() {
     // tabindex makes it focusable, allowing us to test focus restore issues.
     cssButton('My Menu',
       testId('btn1'),
-      { tabindex: "-1" },
+      { tabindex: "0" },
       menu(makeMenu, {
         parentSelectorToMark: '.' + cssExample.className,
         trigger: ['click', {keys: ['Enter']}],

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -3,7 +3,7 @@
  */
 // tslint:disable:no-console
 import {dom, DomElementArg, input, makeTestId, obsArray, observable, styled, TestId} from 'grainjs';
-import {cssMenuDivider, menu, menuItem, menuItemLink, menuItemSubmenu, popupOpen} from '../../index';
+import {cssMenuDivider, menu, menuGroup, menuItem, menuItemLink, menuItemSubmenu, popupOpen} from '../../index';
 import {IOpenController, PopupControl} from '../../index';
 import {autocomplete, inputMenu, select} from '../../index';
 
@@ -87,6 +87,23 @@ function setupTest() {
         menuItem(() => {}, 'Disabled stuff', dom.cls('disabled')),
         menuItem(() => {}, 'Disabled stuff', dom.attr('aria-disabled', 'true')),
         menuItem(() => {}, 'Disabled stuff', dom.cls('disabled')),
+      ]),
+    ),
+    cssButton('My Menu with grouped items',
+      {tabindex: '0'},
+      testId('btn-only-disabled-items'),
+      menu(() => [
+        testId('only-disabled-items-menu'),
+        menuGroup('Grouped items header',
+          menuItem(() => {}, 'Grouped item 1'),
+          menuItem(() => {}, 'Grouped item 2'),
+          menuItem(() => {}, 'Grouped item 3'),
+        ),
+        menuGroup('Grouped items header 2',
+          menuItem(() => {}, 'Grouped item 1'),
+          menuItem(() => {}, 'Grouped item 2', dom.attr('aria-disabled', 'true')),
+          menuItem(() => {}, 'Grouped item 3'),
+        ),
       ]),
     ),
     makeSelect(),

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -91,18 +91,19 @@ function setupTest() {
     ),
     cssButton('My Menu with grouped items',
       {tabindex: '0'},
-      testId('btn-only-disabled-items'),
+      testId('btn-grouped-items'),
       menu(() => [
-        testId('only-disabled-items-menu'),
+        testId('grouped-items-menu'),
+        menuItem(() => lastAction.set('Ungrouped item click'), 'Ungrouped item', testId('ungrouped-item')),
         menuGroup('Grouped items header',
-          menuItem(() => {}, 'Grouped item 1'),
-          menuItem(() => {}, 'Grouped item 2'),
-          menuItem(() => {}, 'Grouped item 3'),
+          menuItem(() => lastAction.set('Grouped item click 1'), 'Grouped item 1', testId('grouped-item1')),
+          menuItem(() => lastAction.set('Grouped item click 2'), 'Grouped item 2', testId('grouped-item2')),
+          menuItemSubmenu(makePasteSubmenu, {}, 'Grouped submenu', testId('grouped-sub-item')),
         ),
         menuGroup('Grouped items header 2',
-          menuItem(() => {}, 'Grouped item 1'),
+          menuItem(() => lastAction.set('Grouped item click 2.1'), 'Grouped item 1'),
           menuItem(() => {}, 'Grouped item 2', dom.attr('aria-disabled', 'true')),
-          menuItem(() => {}, 'Grouped item 3'),
+          menuItem(() => lastAction.set('Grouped item click 2.3'), 'Grouped item 3'),
         ),
       ]),
     ),
@@ -192,6 +193,7 @@ function makePasteSubmenu(): DomElementArg[] {
     menuItem(() => lastAction.set('Cut2'), "Cut2", testId('cut2')),
     menuItem(() => lastAction.set('Copy2'), "Copy2", testId('copy2')),
     menuItem(() => lastAction.set('Paste2'), "Paste2", testId('paste2')),
+    makeCheckboxItem('Checkbox test', testId('sub-item-checkbox')),
     menuItemSubmenu(makePasteSubmenu, {}, "Paste Special2", testId('sub-item2')),
     menuItemSubmenu(makePasteSubmenu, {}, "Paste Special2 with really long text", testId('sub-item2b')),
   ];
@@ -289,7 +291,7 @@ function makeComplexAutocomplete(): HTMLInputElement {
   });
 }
 
-function makeCheckboxItem(label: string) {
+function makeCheckboxItem(label: string, ...args: DomElementArg[]) {
   const checkboxObs = observable(false);
   return menuItem(() => {
     checkboxObs.set(!checkboxObs.get());
@@ -306,6 +308,7 @@ function makeCheckboxItem(label: string) {
         dom.prop("checked", checkboxObs),
       ))
     ),
+    ...args,
   ]);
 }
 
@@ -408,6 +411,7 @@ const cssInput = styled(input, `
 
 const cssInputMenu = styled('div', `
   min-width: 100%;
+  z-index: 9999;
 `);
 
 const funkyOptions = {

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -69,6 +69,16 @@ function setupTest() {
         },
       }),
     ),
+    cssButton('My Menu with only checkbox items',
+      {tabindex: '0'},
+      testId('btn-only-checkbox-items'),
+      menu(() => [
+        testId('only-checkbox-items-menu'),
+        makeCheckboxItem('Checkbox 1'),
+        makeCheckboxItem('Checkbox 2'),
+        makeCheckboxItem('Checkbox 3'),
+      ]),
+    ),
     makeSelect(),
     makeComplexSelect(),
     cssInputContainer(
@@ -137,6 +147,7 @@ function makeMenu(ctl: IOpenController): DomElementArg[] {
       placement: 'right',
     }), "popup", testId('popup-open')
     ),
+    makeCheckboxItem('Checkbox test'),
     cssMenuDivider(),
     menuItemSubmenu(makePasteSubmenu, {
       expandIcon: () => dom('div', '->'),
@@ -249,6 +260,26 @@ function makeComplexAutocomplete(): HTMLInputElement {
       return content.find((el: any) => el.textContent.startsWith(val)) || null;
     }
   });
+}
+
+function makeCheckboxItem(label: string) {
+  const checkboxObs = observable(false);
+  return menuItem(() => {
+    checkboxObs.set(!checkboxObs.get());
+    lastAction.set(`${label} toggle: ${checkboxObs.get()}`);
+  }, [
+    {role: 'menuitemcheckbox'},
+    dom('label',
+      dom('span', label),
+      dom('span', dom('input',
+        {
+          type: 'checkbox',
+          value: 'test',
+        },
+        dom.prop("checked", checkboxObs),
+      ))
+    ),
+  ]);
 }
 
 function buildPopupContent(ctl: IOpenController): HTMLElement {

--- a/test/fixtures/menu.ts
+++ b/test/fixtures/menu.ts
@@ -3,7 +3,7 @@
  */
 // tslint:disable:no-console
 import {dom, DomElementArg, input, makeTestId, obsArray, observable, styled, TestId} from 'grainjs';
-import {cssMenuDivider, menu, menuGroup, menuItem, menuItemLink, menuItemSubmenu, popupOpen} from '../../index';
+import {cssMenuDivider, menu, menuGroup, menuItem, menuItemCheckbox, menuItemLink, menuItemSubmenu, popupOpen} from '../../index';
 import {IOpenController, PopupControl} from '../../index';
 import {autocomplete, inputMenu, select} from '../../index';
 
@@ -38,7 +38,7 @@ function setupTest() {
     // tabindex makes it focusable, allowing us to test focus restore issues.
     cssButton('My Menu',
       testId('btn1'),
-      { tabindex: "0" },
+      { tabindex: "0", role: "button" },
       menu(makeMenu, {
         parentSelectorToMark: '.' + cssExample.className,
         trigger: ['click', {keys: ['Enter']}],
@@ -46,7 +46,7 @@ function setupTest() {
     ),
     cssButton('My Contextmenu',
       testId('btn2'),
-      { tabindex: "-1" },
+      { tabindex: "-1", role: "button" },
       menu(makeMenu, {
         trigger: ['contextmenu'],
         parentSelectorToMark: '.' + cssExample.className
@@ -75,7 +75,7 @@ function setupTest() {
       menu(() => [
         testId('only-checkbox-items-menu'),
         makeCheckboxItem('Checkbox 1'),
-        makeCheckboxItem('Checkbox 2'),
+        makeCheckboxItem('Checkbox 2', {"aria-disabled": "true"}),
         makeCheckboxItem('Checkbox 3'),
       ]),
     ),
@@ -101,9 +101,11 @@ function setupTest() {
           menuItemSubmenu(makePasteSubmenu, {}, 'Grouped submenu', testId('grouped-sub-item')),
         ),
         menuGroup('Grouped items header 2',
-          menuItem(() => lastAction.set('Grouped item click 2.1'), 'Grouped item 1'),
-          menuItem(() => {}, 'Grouped item 2', dom.attr('aria-disabled', 'true')),
-          menuItem(() => lastAction.set('Grouped item click 2.3'), 'Grouped item 3'),
+          menuItem(() => lastAction.set('Grouped item click 2.1'), 'Grouped item 2.1'),
+          menuItemLink({href: 'https://getgrist.com'}, 'Grouped item link 2.2', {"aria-disabled": "true"}),
+          makeCheckboxItem('Grouped checkbox 2.3'),
+          menuItem(() => {}, 'Grouped item 2.4', dom.attr('aria-disabled', 'true')),
+          menuItem(() => lastAction.set('Grouped item click 2.5'), 'Grouped item 2.5'),
         ),
       ]),
     ),
@@ -293,12 +295,9 @@ function makeComplexAutocomplete(): HTMLInputElement {
 
 function makeCheckboxItem(label: string, ...args: DomElementArg[]) {
   const checkboxObs = observable(false);
-  return menuItem(() => {
-    checkboxObs.set(!checkboxObs.get());
-    lastAction.set(`${label} toggle: ${checkboxObs.get()}`);
-  }, [
-    {role: 'menuitemcheckbox'},
-    dom.attr("aria-checked", use => use(checkboxObs) ? "true" : "false"),
+  return menuItemCheckbox(checkboxObs,
+    // Note: a label is not required at all semantically since we are in a menu,
+    // but we want to test behavior when a label is used.
     dom('label',
       dom('span', label),
       dom('span', dom('input',
@@ -310,7 +309,7 @@ function makeCheckboxItem(label: string, ...args: DomElementArg[]) {
       ))
     ),
     ...args,
-  ]);
+  );
 }
 
 function buildPopupContent(ctl: IOpenController): HTMLElement {
@@ -424,7 +423,7 @@ const cssPopupContent = styled('div', `
 `);
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.body.appendChild(setupTest());
+  document.querySelector('main')!.appendChild(setupTest());
 });
 
 const cssOverride = styled('div', `

--- a/test/fixtures/template.html
+++ b/test/fixtures/template.html
@@ -4,6 +4,7 @@
     <meta charset="utf8">
   </head>
   <body>
+    <main></main>
     <script src='build/<NAME>.bundle.js'></script>
   </body>
 </html>


### PR DESCRIPTION
Hey there @dsagal :eyes: 

This is a suggestion to update the DOM generated by selects so that it better matches expected behaviors with screen readers and other assistive tools.

The idea is that screen readers (SR) can now better vocalize what is happening:

- make the select trigger an actual button instead of a div so that SRs can better use it, meaning the trigger is now correctly announced as a button, and for example SR users now have the select triggers in their buttons list, when navigating "by button" through their screen reader UI,
- the select trigger element follows the ARIA Disclosure pattern so that SRs can announce if it is collapsed or not: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/. the "aria-haspopup" attribute also enables SR to announce in advance _what_ will be opened when clicked (here, a list)
- allow using the Enter key to open the dropdown, as usually expected when using this kind of UI. I realize this is not necessarily the behavior of `select` elements and I guess that was the logic behind not having this behavior at first. But these are not _selects_ in strict html terms, these are _buttons_ and exposed as such to assistive techs, and buttons are expected to be triggered with Enter. So, not being able to trigger it with Enter is actually a little issue here
- the select content is now exposed as an ARIA _listbox_ containing _options_ https://www.w3.org/WAI/ARIA/apg/patterns/listbox/. It more-or-less matches the semantics of a _select_ element, just with homemade HTML. Now screen readers and others can use that semantic and expose it to the user.

I'm sure this can be tinkered with a little more but that is already a pretty good first step!